### PR TITLE
Fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and as such has almost mirrored the [RFC process the Rust developers
 use](https://github.com/rust-lang/rfcs), which is tried and tested and appears
 to work very well._
 
-#Introduction
+# Introduction
 
 Many changes, including bug fixes and documentation improvements can be
 implemented and reviewed via the normal GitHub pull request workflow.

--- a/active/0000-Unified-structured-data.md
+++ b/active/0000-Unified-structured-data.md
@@ -1,4 +1,4 @@
-- Feature Name: Unify Structured  data 
+- Feature Name: Unify Structured  data
 - Type: Enhancement
 - Related components: routing, maidsafe_types, maidsafe_vault, maidsafe_client, sentinel
 - Start Date: 13-06-2015
@@ -42,7 +42,7 @@ It is expected removing Transaction Managers from network will reduce complexity
 
 # Detailed design
 
-The design entails reducing all StructuredData types to a single type, therefore it should be able to be recognised by the network as StructuredData and all such sub-types handled exactly in the same manner. 
+The design entails reducing all StructuredData types to a single type, therefore it should be able to be recognised by the network as StructuredData and all such sub-types handled exactly in the same manner.
 
 ##StructuredData
 
@@ -54,7 +54,7 @@ data : mut Vec<u8>, // in many cases this is encrypted
 owner_keys : mut vec<crypto::sign::PublicKey> // n * 32 Bytes (where n is number of owners)
 version : mut u64, // incrementing (deterministic) version number
 previous_owner_keys : mut vec<crypto::sign::PublicKey> // n * 32 Bytes (where n is number of
-owners) only required when owners change 
+owners) only required when owners change
 signature : mut Vec<Signature> // signs the `mut` fields above // 32 bytes (using e25519 sig)
 }
 ```
@@ -69,7 +69,7 @@ Fixed (immutable fields)
   smaller than the hash it prevents flooding of a network location.
 - To validate data we confirm signature using hash of (tag_type + version) as nonce. Initial `Put`
   does not require this signature, but does require the owner contain a value.
-- If previous owners is set then the signature is confirmed using those keys (allows owenr
+- If previous owners is set then the signature is confirmed using those keys (allows owner
   change/transfer etc.). In this case the previous owners is only required on first update and may be
   remove in next version if the owners are not changed again.
 - To confirm sender of any `Put` (store or overwrite) then we check the signature of sender using same mechanism. For multiple senders we confirm at least 50% of owners have signed the request for `Put`
@@ -89,7 +89,7 @@ To update such a type the client will `Post` direct (not paying for this again) 
 
 For private data the data filed will be encrypted (at client discretion), for public data this need not be the case as anyone can read that, but only the owner can update it.
 
-##Client perspective 
+##Client perspective
 
 - Decide on a `type_tag` for a new type.
 - use whichever mechanism to create an `Identity` for this type

--- a/active/0000-Unified-structured-data.md
+++ b/active/0000-Unified-structured-data.md
@@ -11,31 +11,31 @@ This does mean a change to default behaviour and is, therefore a significant cha
 
 # Motivation
 
-##Why?
+## Why?
 
 The primary goal is two fold, reduce network traffic (by removing an indirection, of looking up a value
 and using that as a key to lookup next) and also to remove complexity (thereby increasing security).
 
 Another facet of this proposal is extendibility. In networks such as SAFE for instance, client app developers can define their own types (say of the `fix` protocol for financial transactions) and instantiate this type on the network. For users creating their own network they may white list or blacklist types and type_id's as they wish, but the possibility would exist for network builders (of new networks) to allow extensibility of types.  
 
-##What cases does it support?
+## What cases does it support?
 
 This change supports all use of non immutable data (structured data). This covers all non `content only` data
 on the network and how it is handled.
 
-###Data storage and retrieval
+### Data storage and retrieval
 
 ImmutableData is fixed self validating non mutable chunks. These require StructuredData types to manipulate information. These structured Data types may then create a global application acting on a key value store with very high degrees of availability and security (i.e. create network scale apps). Such apps could easily include medical condition analysis linked with genomic and proteomic sequencing to advance health based knowledge on a global scale. This proposal allows such systems to certainly be prototyped and tested with a high degree of flexibility.
 
-###New protocols
+### New protocols
 
 As these data types are now self validating and may contain different information, such as new protocols, `rdf`/`owl` data types, the limit of new data types and ability to link such data is extremely scalable. Such protocols could indeed easily encompass token based systems (a form of 'crypto-currency'), linked data, natural language learning databases, pre-compilation units, distributed version control systems (git like) etc.
 
-###Compute
+### Compute
 
 Such a scheme would allow global computation types, possibly a Domain Specific Language (DSL) would define operator types to allow combination of functions. These could be made monotonic and allow out of order processing of programs (disorderly programming) which in itself presents an area that may prove to be well aligned with decentralised 'intelligence' efforts. Linked with 'zk-snarks' to alleviate any 'halting problem' type issues then a global Turing complete programming environment that optionally acts on semantic ('owl' / 'json-ld' etc.) data is a possible.
 
-##Expected outcome
+## Expected outcome
 
 
 It is expected removing Transaction Managers from network will reduce complexity, code and increase security on the network, whilst allowing a greater degree of flexibility. These types now allow the users of this network to create their own data types and structures to be securely managed. This is hoped to allow many new types of application to exist.
@@ -44,7 +44,7 @@ It is expected removing Transaction Managers from network will reduce complexity
 
 The design entails reducing all StructuredData types to a single type, therefore it should be able to be recognised by the network as StructuredData and all such sub-types handled exactly in the same manner.
 
-##StructuredData
+## StructuredData
 
 ```
 struct StructuredData {
@@ -63,7 +63,7 @@ Fixed (immutable fields)
 - tag_type
 - identifier
 
-##Validation
+## Validation
 
 - To confirm name (storage location on network) we SHA512(tag_type + identifier). As these are much
   smaller than the hash it prevents flooding of a network location.
@@ -89,7 +89,7 @@ To update such a type the client will `Post` direct (not paying for this again) 
 
 For private data the data filed will be encrypted (at client discretion), for public data this need not be the case as anyone can read that, but only the owner can update it.
 
-##Client perspective
+## Client perspective
 
 - Decide on a `type_tag` for a new type.
 - use whichever mechanism to create an `Identity` for this type
@@ -98,7 +98,7 @@ For private data the data filed will be encrypted (at client discretion), for pu
 - Get from network via `routing::Get(Identity: name, Data::type : type, u64: type_tag);`
 - Mutate on network via `routing::Put(Identity: location, Data::StructuredData : data, u64: type_tag);`
 - Delete from network via `routing::Delete(Identity: name, Data::type : type, u64: type_tag);`
-##Security
+## Security
 
 ### Replay attack avoidance
 

--- a/active/0001-Use-public-key-for-id-on-all-messages.md
+++ b/active/0001-Use-public-key-for-id-on-all-messages.md
@@ -1,57 +1,57 @@
-- Feature Name: Use public key alone to authorise actions 
+- Feature Name: Use public key alone to authorise actions
 - Type Enhancement
 - Related components routing, maidsafe_types, maidsafe_client, maidsafe_vault
 - Start Date: 23-06-2015
-- Issue number: #22 
+- Issue number: #22
 
 # Summary
 
 At the moment client Id packets are created and a hash of these packets used as identity.
 This is stored on the network as a `key` (ie the hash) / `value` (the public key) pair.
-These packets have to be available prior to the client storing data onto the network. 
+These packets have to be available prior to the client storing data onto the network.
 
 As the network must confirm a client has paid the network, either by providing resource
-or via a network token (i.e. safecoin). Then it needs to look up the clients public key 
-and confirm the signature of requests come from that client. This is done by querying 
+or via a network token (i.e. safecoin). Then it needs to look up the clients public key
+and confirm the signature of requests come from that client. This is done by querying
 the client ID (Hash), then looking up the ID packet and downloading it to get the public key.
 
-As such this requires an initial `unauthorised put` as the client is not known to the 
-network and cannot be recognised without this. This means essentially the network has to 
-allow unliited `Put` of client Id packets, thereby exposing a risk of wasted network usage.
+As such this requires an initial `unauthorised put` as the client is not known to the
+network and cannot be recognised without this. This means essentially the network has to
+allow unlited `Put` of client Id packets, thereby exposing a risk of wasted network usage.
 
-This proposal removes all of this indirection and instead allows the client to be recodnised
-by the public key included in messages or data types. such messages and data types will be 
+This proposal removes all of this indirection and instead allows the client to be recognised
+by the public key included in messages or data types. such messages and data types will be
 signed by the `secret key` that is paired with this public key. As only the owner should have
-access to this `secret key` then it can be assumed the message or request to mutate data is 
+access to this `secret key` then it can be assumed the message or request to mutate data is
 indeed valid in a cryptographically secure manner.
 
 # Motivation
 
 Storing Id packets is a strain on the network. Lookups are a strain and will slow down
 network actions. Id packets themselves may be a security issue (can they be hacked), although
-highly unlikely, it is impossible to hack if they do not exist! 
+highly unlikely, it is impossible to hack if they do not exist!
 
-This mechanism does not reduce the total number of clients or types of clients as they all exist 
-in an address space of 2^256 and app developers can use multiple Id's in very clever ways, such 
+This mechanism does not reduce the total number of clients or types of clients as they all exist
+in an address space of 2^256 and app developers can use multiple Id's in very clever ways, such
 as the SAFE network does not distinguish between public id's and private id's. Now these and more are possible.
 Id's could be created to share data types (as co-owners) and allow shares access and write capability
-between applications and groups. 
+between applications and groups.
 
 # Detailed design
 
-As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the 
+As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the
 ClientManager type persona (MaidManager in the case of data). These requests are signed and include the
-clients `PublicKey`. This public key can be allocated, or matched to an existing,to a client account. 
-The ClientManager may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key. 
+clients `PublicKey`. This public key can be allocated, or matched to an existing,to a client account.
+The ClientManager may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key.
 
-If a client wishes to amend any data (structured data) then this is already signed by that client and contains the 
+If a client wishes to amend any data (structured data) then this is already signed by that client and contains the
 `PublicKey` The client will sign the request to alter the data (by overwriting with a new valid one) and again
 the public key of the signed message is included in the message, confirming what key made the request. This key
 can then be confirmed to be one of the owners of the `StructuredData` element and if multiple owners
 then the signatures of the data element being uploaded is checked against the list of signatures of the new chunk
-using the owners keys of the last chunk. 
+using the owners keys of the last chunk.
 
-Clients may identify themselves using the public key as their node address. Signing the request to join the network 
+Clients may identify themselves using the public key as their node address. Signing the request to join the network
 at that address. This is a different size key from routing nodes though, which is a benefit as it distinguishes these
 connections more clearly. This does require a change to the routing API to accommodate 32 byte node identities.
 

--- a/active/0003-reserved_names.md
+++ b/active/0003-reserved_names.md
@@ -12,7 +12,7 @@ A very simple RFC to outline and maintain (over time) a known list of `type_tags
 
 As with `IANA` type registries or indeed the common well known service ports found in many Operating Systems (OSs)
 this list will allow applications that achieve the happy position of being commonplace, or extremely popular to 
-register their `type_tag` in this file. This allows othr application developers to choose a non registered tag to 
+register their `type_tag` in this file. This allows other application developers to choose a non registered tag to
 reduce any confusion or name collisions (although the latter is extremely improbable, given the address space).
 
 # Detailed design
@@ -37,8 +37,8 @@ reduce any confusion or name collisions (although the latter is extremely improb
 
 10,001-2^64  --      Available
 
-The numbers 0-10,000 will be hard coded into vaults for the use of the core network only and will not be likely 
-available to application developers to overwrite their structure. 
+The numbers 0-10,000 will be hard coded into vaults for the use of the core network only and will not be likely
+available to application developers to overwrite their structure.
 
 # Drawbacks
 
@@ -46,7 +46,7 @@ None known
 
 # Alternatives
 
-Alternatively this list could not exist and there could be a free for all approach. 
+Alternatively this list could not exist and there could be a free for all approach.
 
 # Unresolved questions
 

--- a/active/README.md
+++ b/active/README.md
@@ -1,1 +1,1 @@
-#Active RFC's
+# Active RFC's

--- a/agreed/0004-Farm-attempt.md
+++ b/agreed/0004-Farm-attempt.md
@@ -1,43 +1,43 @@
-- Feature Name:Farm attempt 
+- Feature Name:Farm attempt
 - Type new feature
 - Related components maidsafe_vault
-- Start Date: 24-06-2015 
+- Start Date: 24-06-2015
 - Issue number: #25
 
 # Summary
 
-This proposal outlines an initial design to test the efficiency and security of farming attempts.  This involves making use of the Farming Rate (FR) which is the rate at which farming attempts are made.  It is assumed the farming rate will include payments to care development, content producers and most significantly farmers (or providers of the network resource). 
+This proposal outlines an initial design to test the efficiency and security of farming attempts.  This involves making use of the Farming Rate (FR) which is the rate at which farming attempts are made.  It is assumed the farming rate will include payments to care development, content producers and most significantly farmers (or providers of the network resource).
 
 # Motivation
 
-To ensure network stability and resource availability a reward mechanism is required to ensure the use of resource is balanced with the supply of resource. 
+To ensure network stability and resource availability a reward mechanism is required to ensure the use of resource is balanced with the supply of resource.
 
 # Scope of work
 
-This implementation will be solely in the vault library. This will include several steps. The client lib will require to be aware of the actual safecoin type (again `StructuredData`). 
+This implementation will be solely in the vault library. This will include several steps. The client lib will require to be aware of the actual safecoin type (again `StructuredData`).
 
 # Detailed design
 
 ON receipt of a `Get` request for `ImmutableData` the `DataManager` calculates the SHA512 Hash of the `name()` of the `ImmutableData` concatenated with the`PmidNode`. This result is then modulo divided by the farming rate (FR). The rate attempts should divide the award between 4 distinct groups. (for clarity, this algorithm is applied to all `PmidNodes` that hold this data element in the current group).
 
-##Rate attempts 
+## Rate attempts
 
 1. PmidNodes -> tested at 100% of FR [i.e. Farming rate * 1]
-2. App Developer -> tested at 10% of FR [i.e. Farming rate * 1.1] 
+2. App Developer -> tested at 10% of FR [i.e. Farming rate * 1.1]
 3. Publisher -> tested at 10% of FR [i.e. Farming rate * 1.1]
 4. Core development -> tested at 5% of FR [i.e. Farming rate * 1.05]
 
-##Payment address 
+## Payment address
 
 1. PmidNodes -> Registers an Optional (if set by user) wallet address on any store of data to it
 2. App Developer -> App developers will include wallet address in any `Get` request
 3. Publisher -> As data is stored a wallet address of the owner is stored if this is first time seen on the network (stored in DM account for the data element)
 4. Core development -> Initially every node will be aware of a hard coded wallet address for core development. This will likely lead to a multisig wallet.
 
-##Farm process
+## Farm process
 
 When the initial farming test above is true (the modulo division ==0 ) then the `DataManagers` send a Farm request message `Post` to the group closest to the
-combined Hash (i.e. Hash of (`ImmutableData` + `PmidHolder`)). This request includes the original hashes + hash of chunk requested +current farming rate of the group as well as wallet address. This is confirmed at the receiving group and they check for the existence of a safecoin space (ie, there is no safecoin with this name). If this is successful then a further check is made to confirm there is a `DataManager` group (implicit as routing does this). A safecoin is then created and a message sent to the wallet holder of the request.  All these requests must be digitally signed and confirmed at receiving end (implicit in sentnel). 
+combined Hash (i.e. Hash of (`ImmutableData` + `PmidHolder`)). This request includes the original hashes + hash of chunk requested +current farming rate of the group as well as wallet address. This is confirmed at the receiving group and they check for the existence of a safecoin space (ie, there is no safecoin with this name). If this is successful then a further check is made to confirm there is a `DataManager` group (implicit as routing does this). A safecoin is then created and a message sent to the wallet holder of the request.  All these requests must be digitally signed and confirmed at receiving end (implicit in sentnel).
 
 # Drawbacks
 
@@ -45,9 +45,9 @@ Left blank for discussion
 
 # Alternatives
 
-Initially there was no safecoin and the network would have been built in a quid pro quo manner. Thid involved users requiring a vault to store data and the
+Initially there was no safecoin and the network would have been built in a quid pro quo manner. Third involved users requiring a vault to store data and the
 user then being allocated that amount of data to store. It was rather inflexible and involved a tremendous amount of logic. It was an alternative. It should be
-noted the very original designs did include a digital currency which would have suited this purpose perfectly as safecoin now will. 
+noted the very original designs did include a digital currency which would have suited this purpose perfectly as safecoin now will.
 
 # Unresolved questions
 

--- a/agreed/0005-balance_network_resources.md
+++ b/agreed/0005-balance_network_resources.md
@@ -1,8 +1,8 @@
-- Feature Name: Balance network resources 
+- Feature Name: Balance network resources
 - Type new feature
-- Related components maidsafe_vault 
-- Start Date: 25-06-2015 
-- Issue number: #26 
+- Related components maidsafe_vault
+- Start Date: 25-06-2015
+- Issue number: #26
 
 # Summary
 
@@ -11,58 +11,58 @@ resources that users are charged. The farming rate is calculated by the network 
 As the farming rate increases, farmers earn less as more `Get` requests per attempt is required.
 As the farming rate increases then it follows users pay less (as the network is oversupplied) for
 resources. The key issue is to identify the link between these two numbers. It is assumed
-all chunks are 1Mb in this proposition, this is very realistic in terms of calculation and 
-any error favours the user. 
+all chunks are 1Mb in this proposition, this is very realistic in terms of calculation and
+any error favours the user.
 
 # Motivation
 
 This decentralised autonomous network must encourage resource providers. This is anticipated
-to be similar to skype, bittorrent etc. in that people will provide resources, simply because 
+to be similar to skype, bittorrent etc. in that people will provide resources, simply because
 they are getting something from the network. This proposal enhances safecoin to provide an
 additional encouragement. That incentive is the payment of providers of resources to include
 application development, content availability and importantly resources, in terms of disk space,
 cpu processing, memory, bandwidth etc. in fact everything required to provide data availability
 (and compute) to all users, irrespective of the use or users.
 
-Many confuse any out of network price fluctuation would in fact alter the network balancing process, 
+Many confuse any out of network price fluctuation would in fact alter the network balancing process,
 in fact it is unrelated as the balance simply increases reward when space is needed and reduces when
-space is abundant. There is no relation to the cost of safecoin and network balancing, as long as 
+space is abundant. There is no relation to the cost of safecoin and network balancing, as long as
 a safecoin can change hands for a cost then the number of safecoin per unit of fiat is handled by
 the network.
 
 # Detailed design
 
-A very simple approach is to use a fixed approach and measure via testing. It is assumed there will 
-be considerably more reads from the network than stores of data. The cost per MB, electricity, B/W 
-and size of storage are all factors in this algorithm. Therefore testing and sampling of a running 
-network is essential. To begin the simple approach is best. 
+A very simple approach is to use a fixed approach and measure via testing. It is assumed there will
+be considerably more reads from the network than stores of data. The cost per MB, electricity, B/W
+and size of storage are all factors in this algorithm. Therefore testing and sampling of a running
+network is essential. To begin the simple approach is best.
 
 `int cost_per_Mb = 1/(fr^(1/5));`  (5th root, integer value)
 
-Where 1 is a 1MB chunk. It is assumed the figure will alter under scrutiny of network testing, but 
+Where 1 is a 1MB chunk. It is assumed the figure will alter under scrutiny of network testing, but
 this is assumption (based on usage increase (X10 pa total), price decrease (1/2 pa) etc. over time)
-as well as b/w usage, which widely varies across countries at the moment. 
+as well as b/w usage, which widely varies across countries at the moment.
 
 The FR is the local farming rate known to the `ClientManager` and may slightly vary through time across
-the network. This is expected and as the network grows the spread of cost will equalise as the binary 
-tree balances. 
+the network. This is expected and as the network grows the spread of cost will equalise as the binary
+tree balances.
 
-`ClientManagers` will expect at least a whole safecoin in advance, which is `burned` (i.e. the client 
-sends a `Delete` for a safecoin (which the `ClientManager` checks)). The balance of this payment is 
-reduced per `Put`. This `Delete` call will pass through `ClientManagers` who can immediately add the 
+`ClientManagers` will expect at least a whole safecoin in advance, which is `burned` (i.e. the client
+sends a `Delete` for a safecoin (which the `ClientManager` checks)). The balance of this payment is
+reduced per `Put`. This `Delete` call will pass through `ClientManagers` who can immediately add the
 balance and if an `Error` for this `Delete` is returned then reduce the balance and remove the account.
 
-It is assumed clients will pay at least one safecoin to create an account. This payment will be converted immediately to Mb of storage space and the client can query this figure at any time. 
+It is assumed clients will pay at least one safecoin to create an account. This payment will be converted immediately to Mb of storage space and the client can query this figure at any time.
 
 # Drawbacks
 
-1. This is a very simple approach to a balancing algorithm, it could be argued this could be modelled.
+1. This is a very simple approach to a balancing algorithm, it could be argued this could be modeled.
 
 2. Initial feedback and analysis may not reflect network usage as new applications and use profiles
 alter over time.
 
 3. It is very likely the agreed algorithm will evolve over time, which may not be clearly understood by all
-the community, therefore clear RFC proposals and discussions should certainly take place when such 
+the community, therefore clear RFC proposals and discussions should certainly take place when such
 change may happen.
 
 # Alternatives
@@ -72,4 +72,4 @@ that is likely to be more capable of aligning with changing Farming Rates.
 
 # Unresolved questions
 
-Left open to review process to identify 
+Left open to review process to identify

--- a/agreed/README.md
+++ b/agreed/README.md
@@ -1,1 +1,1 @@
-#Agreed RFC's
+# Agreed RFC's

--- a/implemented/README.md
+++ b/implemented/README.md
@@ -1,1 +1,1 @@
-#Implemented RFC's
+# Implemented RFC's

--- a/proposed/README.md
+++ b/proposed/README.md
@@ -1,1 +1,1 @@
-#Proposed RFC's
+# Proposed RFC's

--- a/rejected/README.md
+++ b/rejected/README.md
@@ -1,1 +1,1 @@
-#Rejected RFC's
+# Rejected RFC's


### PR DESCRIPTION
This pull request fixes various spelling errors and standardises the markdown format with the standard set by GitHub.

https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#headers

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/rfcs/31)
<!-- Reviewable:end -->
