### PR TITLE
Typos, improved grammar and formatting for agreed and implemented RFCs

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,6 +1,6 @@
 - Feature Name: (fill me in with a unique identity, my_awesome_feature)
-- Type (new feature, enhancement)
-- Related components (if any)
+- Type: (new feature, enhancement)
+- Related components: (if any)
 - Start Date: (fill me in with today's date, DD-MM-YYYY)
 - RFC PR: (leave this empty)
 - Issue number: (leave this empty)

--- a/agreed/0004-Farm-attempt/0004-Farm-attempt.md
+++ b/agreed/0004-Farm-attempt/0004-Farm-attempt.md
@@ -1,12 +1,12 @@
-- Feature Name:Farm attempt
-- Type new feature
-- Related components maidsafe_vault
+- Feature Name: Farm attempt
+- Type: new feature
+- Related components: maidsafe_vault
 - Start Date: 24-06-2015
 - Issue number: #25
 
 # Summary
 
-This proposal outlines an initial design to test the efficiency and security of farming attempts.  This involves making use of the Farming Rate (FR) which is the rate at which farming attempts are made.  It is assumed the farming rate will include payments to care development, content producers and most significantly farmers (or providers of the network resource).
+This proposal outlines an initial design to test the efficiency and security of farming attempts. This involves making use of the Farming Rate (FR) which is the rate at which farming attempts are made. It is assumed the farming rate will include payments to care development, content producers and most significantly farmers (or providers of the network resource).
 
 # Motivation
 
@@ -18,7 +18,7 @@ This implementation will be solely in the vault library. This will include sever
 
 # Detailed design
 
-ON receipt of a `Get` request for `ImmutableData` the `DataManager` calculates the SHA512 Hash of the `name()` of the `ImmutableData` concatenated with the`PmidNode`. This result is then modulo divided by the farming rate (FR). The rate attempts should divide the award between 4 distinct groups. (for clarity, this algorithm is applied to all `PmidNodes` that hold this data element in the current group).
+On receipt of a `Get` request for `ImmutableData` the `DataManager` calculates the SHA512 Hash of the `name` of the `ImmutableData` concatenated with the`PmidNode`. This result is then modulo divided by the farming rate (FR). The rate attempts should divide the award between 4 distinct groups (for clarity, this algorithm is applied to all `PmidNodes` that hold this data element in the current group).
 
 ## Rate attempts
 
@@ -32,12 +32,11 @@ ON receipt of a `Get` request for `ImmutableData` the `DataManager` calculates t
 1. PmidNodes -> Registers an Optional (if set by user) wallet address on any store of data to it
 2. App Developer -> App developers will include wallet address in any `Get` request
 3. Publisher -> As data is stored a wallet address of the owner is stored if this is first time seen on the network (stored in DM account for the data element)
-4. Core development -> Initially every node will be aware of a hard coded wallet address for core development. This will likely lead to a multisig wallet.
+4. Core development -> Initially every node will be aware of a hard coded wallet address for core development. This will likely lead to a multi-sign wallet.
 
 ## Farm process
 
-When the initial farming test above is true (the modulo division ==0 ) then the `DataManagers` send a Farm request message `Post` to the group closest to the
-combined Hash (i.e. Hash of (`ImmutableData` + `PmidHolder`)). This request includes the original hashes + hash of chunk requested +current farming rate of the group as well as wallet address. This is confirmed at the receiving group and they check for the existence of a safecoin space (ie, there is no safecoin with this name). If this is successful then a further check is made to confirm there is a `DataManager` group (implicit as routing does this). A safecoin is then created and a message sent to the wallet holder of the request.  All these requests must be digitally signed and confirmed at receiving end (implicit in sentnel).
+When the initial farming test above is true (the modulo division `==0` ) then the `DataManager`s `Post` a Farm request message to the group closest to the combined Hash (i.e. `Hash(ImmutableData + PmidHolder)`). This request includes the original hashes + hash of chunk requested + current farming rate of the group as well as wallet address. This is confirmed at the receiving group and they check for the existence of a safecoin space (i.e. there is no safecoin with this name already). If this is successful then a further check is made to confirm there is a `DataManager` group (implicit as routing does this). A safecoin is then created and a message sent to the wallet holder of the request. All these requests must be digitally signed and confirmed at receiving end (implicit in sentnel).
 
 # Drawbacks
 
@@ -45,9 +44,7 @@ Left blank for discussion
 
 # Alternatives
 
-Initially there was no safecoin and the network would have been built in a quid pro quo manner. Third involved users requiring a vault to store data and the
-user then being allocated that amount of data to store. It was rather inflexible and involved a tremendous amount of logic. It was an alternative. It should be
-noted the very original designs did include a digital currency which would have suited this purpose perfectly as safecoin now will.
+Initially there was no safecoin and the network would have been built in a quid pro quo manner. Third involved users requiring a vault to store data and the user then being allocated that amount of data to store. It was rather inflexible and involved a tremendous amount of logic. It was an alternative. It should be noted the very original designs did include a digital currency which would have suited this purpose perfectly as safecoin now will.
 
 # Unresolved questions
 

--- a/agreed/0005-balance_network_resources/0005-balance_network_resources.md
+++ b/agreed/0005-balance_network_resources/0005-balance_network_resources.md
@@ -6,51 +6,25 @@
 
 # Summary
 
-This proposals intent is to provide a balance for Farming Rate verses purchase price of network
-resources that users are charged. The farming rate is calculated by the network in another RFC.
-As the farming rate increases, farmers earn less as more `Get` requests per attempt is required.
-As the farming rate increases then it follows users pay less (as the network is oversupplied) for
-resources. The key issue is to identify the link between these two numbers. It is assumed
-all chunks are 1Mb in this proposition, this is very realistic in terms of calculation and
-any error favours the user.
+This proposals intent is to provide a balance for Farming Rate verses purchase price of network resources that users are charged. The farming rate (`fr`) is calculated by the network as described in RFC 0004. As the farming rate increases, farmers earn less as more `Get` requests per attempt is required. As the farming rate increases then it follows users pay less (as the network is oversupplied) for resources. The key issue is to identify the link between these two numbers. It is assumed all chunks are 1Mb in this proposition, this is very realistic in terms of calculation and any error favours the user.
 
 # Motivation
 
-This decentralised autonomous network must encourage resource providers. This is anticipated
-to be similar to skype, bittorrent etc. in that people will provide resources, simply because
-they are getting something from the network. This proposal enhances safecoin to provide an
-additional encouragement. That incentive is the payment of providers of resources to include
-application development, content availability and importantly resources, in terms of disk space,
-cpu processing, memory, bandwidth etc. in fact everything required to provide data availability
-(and compute) to all users, irrespective of the use or users.
+This decentralised autonomous network must encourage resource providers. This is anticipated to be similar to skype, bittorrent etc. in that people will provide resources, simply because they are getting something from the network. This proposal enhances safecoin to provide an additional encouragement. That incentive is the payment of providers of resources to include application development, content availability and importantly resources, in terms of disk space, cpu processing, memory, bandwidth etc. in fact everything required to provide data availability (and compute) to all users, irrespective of the use or users.
 
-Many confuse any out of network price fluctuation would in fact alter the network balancing process,
-in fact it is unrelated as the balance simply increases reward when space is needed and reduces when
-space is abundant. There is no relation to the cost of safecoin and network balancing, as long as
-a safecoin can change hands for a cost then the number of safecoin per unit of fiat is handled by
-the network.
+Many confuse any out of network price fluctuation would in fact alter the network balancing process, in fact it is unrelated as the balance simply increases reward when space is needed and reduces when space is abundant. There is no relation to the cost of safecoin and network balancing, as long as a safecoin can change hands for a cost then the number of safecoin per unit of fiat is handled by the network.
 
 # Detailed design
 
-A very simple approach is to use a fixed approach and measure via testing. It is assumed there will
-be considerably more reads from the network than stores of data. The cost per MB, electricity, B/W
-and size of storage are all factors in this algorithm. Therefore testing and sampling of a running
-network is essential. To begin the simple approach is best.
+A very simple approach is to use a fixed approach and measure via testing. It is assumed there will be considerably more reads from the network than stores of data. The cost per MB, electricity, B/W and size of storage are all factors in this algorithm. Therefore testing and sampling of a running network is essential. To begin the simple approach is best.
 
-`int cost_per_Mb = 1/(fr^(1/5));`  (5th root, integer value)
+`int cost_per_Mb = 1/(FR^(1/5));`  (5th root, integer value)
 
-Where 1 is a 1MB chunk. It is assumed the figure will alter under scrutiny of network testing, but
-this is assumption (based on usage increase (X10 pa total), price decrease (1/2 pa) etc. over time)
-as well as b/w usage, which widely varies across countries at the moment.
+Where 1 is a 1MB chunk. It is assumed the figure will alter under scrutiny of network testing, but this is assumption (based on usage increase (X10 pa total), price decrease (1/2 pa) etc. over time) as well as b/w usage, which widely varies across countries at the moment.
 
-The FR is the local farming rate known to the `ClientManager` and may slightly vary through time across
-the network. This is expected and as the network grows the spread of cost will equalise as the binary
-tree balances.
+The `FR` is the local farming rate known to the `ClientManager` and may slightly vary through time across the network. This is expected and as the network grows the spread of cost will equalise as the binary tree balances.
 
-`ClientManagers` will expect at least a whole safecoin in advance, which is `burned` (i.e. the client
-sends a `Delete` for a safecoin (which the `ClientManager` checks)). The balance of this payment is
-reduced per `Put`. This `Delete` call will pass through `ClientManagers` who can immediately add the
-balance and if an `Error` for this `Delete` is returned then reduce the balance and remove the account.
+`ClientManagers` will expect at least a whole safecoin in advance, which is `burned` (i.e. the client sends a `Delete` for a safecoin (which the `ClientManager` checks)). The balance of this payment is reduced per `Put`. This `Delete` call will pass through `ClientManagers` who can immediately add the balance. Should this `Delete` return with an `Error` the `ClientManager` must reduce the balance and remove the account.
 
 It is assumed clients will pay at least one safecoin to create an account. This payment will be converted immediately to Mb of storage space and the client can query this figure at any time.
 
@@ -58,17 +32,13 @@ It is assumed clients will pay at least one safecoin to create an account. This 
 
 1. This is a very simple approach to a balancing algorithm, it could be argued this could be modeled.
 
-2. Initial feedback and analysis may not reflect network usage as new applications and use profiles
-alter over time.
+2. Initial feedback and analysis may not reflect network usage as new applications and use profiles alter over time.
 
-3. It is very likely the agreed algorithm will evolve over time, which may not be clearly understood by all
-the community, therefore clear RFC proposals and discussions should certainly take place when such
-change may happen.
+3. It is very likely the agreed algorithm will evolve over time, which may not be clearly understood by all the community, therefore clear RFC proposals and discussions should certainly take place when such change may happen.
 
 # Alternatives
 
-It is expected there may be, in fact, a substantially more accurate initial estimate or an algorithm
-that is likely to be more capable of aligning with changing Farming Rates.
+It is expected there may be, in fact, a substantially more accurate initial estimate or an algorithm that is likely to be more capable of aligning with changing Farming Rates.
 
 # Unresolved questions
 

--- a/implemented/0000-Unified-structured-data/0000-Unified-structured-data.md
+++ b/implemented/0000-Unified-structured-data/0000-Unified-structured-data.md
@@ -6,26 +6,24 @@
 
 # Summary
 
-Have network only recognise two primary data types, Immutable and Structured. These types will have tag_ids to allow them to contain several data types that can be used in the network by users of the client interface.
-This does mean a change to default behaviour and is, therefore a significant change. ImmutableData has already two sub-types (Backup and Sacrificial). This proposal should simplify the sentinel and interfaces from routing to users of routing as there will be no need to pass down type information (i.e. how to get the name or owner etc.). These types can actually be defined in the routing library, allowing users of the library to use the `type_tag` to create their own types and actions on those types.
+Have network only recognise two primary data types, Immutable and Structured. These types will have `tag_id`s to allow them to contain several data types that can be used in the network by users of the client interface.
+This does mean a change to default behaviour and is, therefore, a significant change. ImmutableData has already two sub-types (Backup and Sacrificial). This proposal should simplify the sentinel and interfaces from routing to users of routing as there will be no need to pass down type information (i.e. how to get the name or owner etc.). These types can actually be defined in the routing library, allowing users of the library to use the `type_tag` to create their own types and actions on those types.
 
 # Motivation
 
 ## Why?
 
-The primary goal is two fold, reduce network traffic (by removing an indirection, of looking up a value
-and using that as a key to lookup next) and also to remove complexity (thereby increasing security).
+The primary goal is two-fold, reduce network traffic (by removing an indirection, of looking up a value and using that as a key to lookup next) and also to remove complexity (thereby increasing security).
 
-Another facet of this proposal is extendibility. In networks such as SAFE for instance, client app developers can define their own types (say of the `fix` protocol for financial transactions) and instantiate this type on the network. For users creating their own network they may white list or blacklist types and type_id's as they wish, but the possibility would exist for network builders (of new networks) to allow extensibility of types.  
+Another facet of this proposal is extensibility. In networks such as SAFE for instance, client app developers can define their own types (say of the `fix` protocol for financial transactions) and instantiate this type on the network. For users creating their own network they may whitelist or blacklist types and `type_id`s as they wish, but the possibility would exist for network builders (of new networks) to allow extensibility of types.  
 
 ## What cases does it support?
 
-This change supports all use of non immutable data (structured data). This covers all non `content only` data
-on the network and how it is handled.
+This change supports all use of non immutable data (structured data). This covers all non `content only` data on the network and how it is handled.
 
 ### Data storage and retrieval
 
-ImmutableData is fixed self validating non mutable chunks. These require StructuredData types to manipulate information. These structured Data types may then create a global application acting on a key value store with very high degrees of availability and security (i.e. create network scale apps). Such apps could easily include medical condition analysis linked with genomic and proteomic sequencing to advance health based knowledge on a global scale. This proposal allows such systems to certainly be prototyped and tested with a high degree of flexibility.
+`ImmutableData` is fixed self validating non mutable chunks. These require `StructuredData` types to manipulate information. These `StructuredData` types may then create a global application acting on a key value store with very high degrees of availability and security (i.e. create network scale apps). Such apps could easily include medical condition analysis linked with genomic and proteomic sequencing to advance health based knowledge on a global scale. This proposal allows such systems to certainly be prototyped and tested with a high degree of flexibility.
 
 ### New protocols
 
@@ -37,45 +35,38 @@ Such a scheme would allow global computation types, possibly a Domain Specific L
 
 ## Expected outcome
 
-
-It is expected removing Transaction Managers from network will reduce complexity, code and increase security on the network, whilst allowing a greater degree of flexibility. These types now allow the users of this network to create their own data types and structures to be securely managed. This is hoped to allow many new types of application to exist.
+It is expected removing `TransactionManager`s from network will reduce complexity, code and increase security on the network, whilst allowing a greater degree of flexibility. These types now allow the users of this network to create their own data types and structures to be securely managed. This is hoped to allow many new types of application to exist.
 
 # Detailed design
 
-The design entails reducing all StructuredData types to a single type, therefore it should be able to be recognised by the network as StructuredData and all such sub-types handled exactly in the same manner.
+The design entails reducing all `StructuredData` types to a single type, therefore it should be able to be recognised by the network as `StructuredData` and all such sub-types handled exactly in the same manner.
 
 ## StructuredData
 
-```
+```rust
 struct StructuredData {
-tag_type : TagType, // 8 Bytes ?
-identifier : NameType // 64Bytes (i.e. SHA512 Hash)
-data : mut Vec<u8>, // in many cases this is encrypted
-owner_keys : mut vec<crypto::sign::PublicKey> // n * 32 Bytes (where n is number of owners)
-version : mut u64, // incrementing (deterministic) version number
-previous_owner_keys : mut vec<crypto::sign::PublicKey> // n * 32 Bytes (where n is number of
-owners) only required when owners change
-signature : mut Vec<Signature> // signs the `mut` fields above // 32 bytes (using e25519 sig)
+  tag_type : TagType, // 8 Bytes ?
+  identifier : NameType // 64Bytes (i.e. SHA512 Hash)
+  data : mut Vec<u8>, // in many cases this is encrypted
+  owner_keys : mut vec<crypto::sign::PublicKey> // n * 32 Bytes (where n is number of owners)
+  version : mut u64, // incrementing (deterministic) version number
+  previous_owner_keys : mut vec<crypto::sign::PublicKey> // n * 32 Bytes (where n is number of owners) only required when owners change
+  signature : mut Vec<Signature> // signs the `mut` fields above // 32 bytes (using e25519 sig)
 }
 ```
 
 Fixed (immutable fields)
-- tag_type
-- identifier
+- `tag_type`
+- `identifier`
 
 ## Validation
 
-- To confirm name (storage location on network) we SHA512(tag_type + identifier). As these are much
-  smaller than the hash it prevents flooding of a network location.
-- To validate data we confirm signature using hash of (tag_type + version) as nonce. Initial `Put`
-  does not require this signature, but does require the owner contain a value.
-- If previous owners is set then the signature is confirmed using those keys (allows owner
-  change/transfer etc.). In this case the previous owners is only required on first update and may be
-  remove in next version if the owners are not changed again.
+- To confirm name (storage location on network) we `SHA512(tag_type + identifier)`. As these are much smaller than the hash it prevents flooding of a network location.
+- To validate data we confirm signature using hash of (tag_type + version) as nonce. Initial `Put` does not require this signature, but does require the owner contain a value.
+- If previous owners is set then the signature is confirmed using those keys (allows owner change/transfer etc.). In this case the previous owners is only required on first update and may be remove in next version if the owners are not changed again.
 - To confirm sender of any `Put` (store or overwrite) then we check the signature of sender using same mechanism. For multiple senders we confirm at least 50% of owners have signed the request for `Put`
 
-When `Put` on the network this type is `StructuredData` with a subtype field. The network ignores this subtype
-except for collisions. No two data types with the same name and type can exist on the network.
+When `Put` on the network this type is `StructuredData` with a subtype field. The network ignores this subtype except for collisions. No two data types with the same name and type can exist on the network.
 
 These types are stored in a disk based storage mechanism such as `Btree` at the NaeManagers (DataManagers) responsible for the area of the network at that `name`.
 
@@ -98,6 +89,7 @@ For private data the data filed will be encrypted (at client discretion), for pu
 - Get from network via `routing::Get(Identity: name, Data::type : type, u64: type_tag);`
 - Mutate on network via `routing::Put(Identity: location, Data::StructuredData : data, u64: type_tag);`
 - Delete from network via `routing::Delete(Identity: name, Data::type : type, u64: type_tag);`
+
 ## Security
 
 ### Replay attack avoidance
@@ -110,20 +102,20 @@ The removal and validation of client keys is also a significant reduction in com
 
 # Drawbacks
 
-This will put a heavier requirement on `Refresh` calls on the network in times of churn, rather than transferring only keys and versions (which may be small) this will require sending up to 100kB per StructuredData element. If content was always held as immutable data then it is not transferred at every churn event.
-The client will also have more work as when the StructuredData type is larger than 100kB it then has to self_encrypt the remainder and store the datamap in the data filed of the StructuredData. This currently happens in a manner, but every time and without calculation of when.
+This will put a heavier requirement on `Refresh` calls on the network in times of churn, rather than transferring only keys and versions (which may be small) this will require sending up to 100kB per `StructuredData` element. If content was always held as immutable data then it is not transferred at every churn event.
+The client will also have more work as when the `StructuredData` type is larger than 100kB it then has to self_encrypt the remainder and store the datamap in the data filed of the `StructuredData`. This currently happens in a manner, but every time and without calculation of when.
 
 # Alternatives
 
 Status quo is an option and realistic.
 
-- Another option posed by Qi is that structured data types be directly stored on `ManagedNodes` (`PmidNode`), this would reduce churn issues, but may introduce a security concern as we do not trust a `Pmidnode` to not lie or replay and it potentially can with data that is mutable and not intrinsically validatable as accurate.
-- Another possibility by Qi is the `PmidManager` (`NodeManager`) stores the data size separate from the immutableData size.  
+- Another option posed by Qi is that structured data types be directly stored on `ManagedNodes` (`PmidNode`), this would reduce churn issues, but may introduce a security concern as we do not trust a `PmidNode` to not lie or replay and it potentially can with data that is mutable and not intrinsically validatable as accurate.
+- Another possibility proposed by Qi is the `PmidManager` (`NodeManager`) stores the data size separate from the immutableData size.  
 
 
 # Unresolved questions
 
-1. Size of StructuredData packet, it would be nice if it were perhaps 512Bytes to have the best chance to fit into a single UDP packet, although not guaranteed. Means a payload after serialisation of only a few hundred bytes (maybe less)
+1. Size of `StructuredData` packet, it would be nice if it were perhaps 512Bytes to have the best chance to fit into a single UDP packet, although not guaranteed. Means a payload after serialisation of only a few hundred bytes (maybe less)
 2. Version conflicts or out of order updates, will upper layers handle this via a wait condition?
 
 --------------------------------------------------------------------------------
@@ -132,17 +124,11 @@ Status quo is an option and realistic.
 # Summary
 
 [RFC Unified Structured Data](https://github.com/dirvine/rfcs/blob/unified-structured-data/proposed/0000-Unified-structured-data.md) introduces `StructuredData` as a fundamental type for the network.
-This RFC explores in more detail the implications for applying this change for routing
-and sentinel library.  This is not the exact implementation as completed after Rust-3, but appended for reference.
+This RFC explores in more detail the implications for applying this change for routing and sentinel library.  This is not the exact implementation as completed after Rust-3, but appended for reference.
 
 # Motivation
 
-For the motivation on introducing `Unified Structured Data` we refer back to
-the parent RFC.  The motivation for the current RFC is to establish a collective
-understanding of the changes needed for routing and sentinel to
-implementing the parent RFC.  This RFC explicitly excludes the intend to change
-the design of the actual `StructuredData` and any such discussions should be
-posted on the parent RFC.
+For the motivation on introducing `Unified Structured Data` we refer back to the parent RFC. The motivation for the current RFC is to establish a collective understanding of the changes needed for routing and sentinel to implementing the parent RFC. This RFC explicitly excludes the intend to change the design of the actual `StructuredData` and any such discussions should be posted on the parent RFC.
 
 # Detailed design
 
@@ -161,9 +147,7 @@ struct PlainData {
 }
 ```
 
-Routing will not perform any additional validation on the PlainData type.
-Default routing behaviour applies to this type, which is briefly recapitulated
-below.
+Routing will not perform any additional validation on the `PlainData` type. Default routing behaviour applies to this type, which is briefly recapitulated below.
 
 ### Immutable data
 
@@ -177,7 +161,7 @@ impl ImmutableData {
     pub fn new(tag_type: u8, value : Vec<u8>) -> ImmutableData {}
 
     pub fn name(&self) -> NameType {
-        (tag_type + 1) Hash iterations of self.value
+        (tag_type + 1) // Hash iterations of self.value
     }
 
     // add lifetime if needed
@@ -243,57 +227,36 @@ impl StructuredData {
 
 - `data` Routing does not parse the `data` field; it is always considered
 as serialised bytes.
-- `version` Routing does not (currently) attempt to resolve concurreny issues;
-as such `version` is unused at routing.  Additionally routing has no knowledge
-of the previously stored valid version. The version number is for the user.
-- `tag_type` Routing does not attach meaning to the 8 byte `tag_type` and treats
-all tag_types equal.
-- the signature should sign in bytes that are concatenated
-in the following order: `data`, `version`, `owner_keys` and
-`previous_owner_keys` - purely as a matter of convention.
+- `version` Routing does not (currently) attempt to resolve concurrency issues; as such `version` is unused at routing.  Additionally routing has no knowledge of the previously stored valid version. The version number is for the user.
+- `tag_type` Routing does not attach meaning to the 8 byte `tag_type` and treats all `tag_type`s equal.
+- the signature should sign in bytes that are concatenated in the following order: `data`, `version`, `owner_keys` and `previous_owner_keys` - purely as a matter of convention.
 
 Corresponding `get` functions for all data fields are implied.
 
-#### logic for valid succession of structured data
+#### Logic for valid succession of structured data
 
-The structured data is recursively validated strictly on the preceding version.
-That is the validity of a `StructuredData` of version `n` can only depend
-on the validity of the same `StructuredData` of version `n-1`.  Here "same"
-means "have the same name".  For `StructuredData` of version `n = 0` the
-validity is `true` (and hence ClientManagers can charge an account to create
-new valid `StructuredData_v0`).
+The structured data is recursively validated strictly on the preceding version. That is the validity of a `StructuredData` of version `n` can only depend on the validity of the same `StructuredData` of version `n-1`.  Here "same" means "have the same name". For `StructuredData` of version `n = 0` the validity is `true` (and hence ClientManagers can charge an account to create new valid `StructuredData_v0`).
 
-The version number must strictly increase by one.
-All structured data must be owned; transfer of ownership is discussed below.
-A majority is 50%, as outlined in the parent RFC
+The version number must strictly increase by one. All structured data must be owned; transfer of ownership is discussed below. A majority is 50%, as outlined in the parent RFC
 
 **case : previous owner field is empty**
 
 An empty `previous_owner_keys` vector implies that the `owner_keys`
-of version `n` must match the `owner_keys` of version `n-1`.
-The `previous_owner_keys` of version `n-1` is ignored.
-In this case no transfer of ownership is executed.  The signatures must
-be validatable with a majority of the keys of the current owners of version `n`.
+of version `n` must match the `owner_keys` of version `n-1`. The `previous_owner_keys` of version `n-1` is ignored. In this case no transfer of ownership is executed. The signatures must be validatable with a majority of the keys of the current owners of version `n`.
 
 **case : previous owner field is not empty**
 
-A non-empty `previous_owner_keys` vector implies that there is an intent to
-transfer ownership. In this case the `previous_owner_keys` of version `n`
-must match the `owner_keys` of version `n-1`. The signatures must be
+A non-empty `previous_owner_keys` vector implies that there is an intent to transfer ownership. In this case the `previous_owner_keys` of version `n` must match the `owner_keys` of version `n-1`. The signatures must be
 validatable with a majority of the keys of `previous_owner_keys` of version `n`.
 
 #### efficiency consideration when validating the signatures
 
-As outlined above, a signed vector of public keys defines a fixed order of
-the public keys that will be checked to validate the signatures (see above
-on previous owners or not).  On construction of a `StructuredData`
+As outlined above, a signed vector of public keys defines a fixed order of the public keys that will be checked to validate the signatures (see above on previous owners or not). On construction of a `StructuredData`
 the `Vec<Signatures>` will be ordered to the fixed order defined by the
 relevant `Vec<PublicKey>`.
 
-Any validation effort will then in sequence iterate over the signatures, and
-in sequence check the keys, starting from the same index.  This is an
-easy algorithm for minimizing the search for matching signatures.  A better
-algorithm can be suggested.
+Any validation effort will then in sequence iterate over the signatures, and in sequence check the keys, starting from the same index. This is an
+easy algorithm for minimizing the search for matching signatures. A better algorithm can be suggested.
 
 ## Impact on routing message
 
@@ -309,27 +272,20 @@ pub struct RoutingMessage {
 ```
 
 As every client connects to the network over a relocated relay node,
-we can keep this obligatory signature and have it signed by the relay node.
-This puts responsibility on the relay node when injecting client messages in
-the network, and keeps consistency that the from_node on the network is always
-the id of a relocated node, not the hash of a 32byte client PublicKey.
+we can keep this obligatory signature and have it signed by the relay node. This puts responsibility on the relay node when injecting client messages in the network, and keeps consistency that the from_node on the network is always the id of a relocated node, not the hash of a 32byte client PublicKey.
 
-RoutingClient will sign RoutingMessages with the generic unrelocated Id
-it self-generates on construction.  This generic Id is unrelated to the keys
-for signing ownership of structured data; it is purely and internally used
-by routing to identify client-relay connections, per session.
+`RoutingClient` will sign `RoutingMessage`s with the generic unrelocated `Id` it self-generates on construction. This generic `Id` is unrelated to the keys for signing ownership of structured data; it is purely and internally used by routing to identify client-relay connections, per session.
 
-## Conservative approach to MessageTypes
+## Conservative approach to `MessageType`
 
 Routing can reduce to the following message types; the main motivation
-is to simplify the message handlers.  However, we will first go for
+is to simplify the message handlers. However, we will first go for
 a conservative approach and extend the existing paradigm.
 
 This requires updating `GetData`, `GetDataResponse`, `PutData`, `PutDataResponse`.
 It leads to introducing `Post`, `PostResponse`, `Delete`, `DeleteResponse`.
 
-The corresponding handlers need to be updated/written, replacing `serialised_bytes`
-with `UnifiedData`.
+The corresponding handlers need to be updated/written, replacing `serialised_bytes` with `UnifiedData`.
 
 ``` rust
 pub enum UnifiedData {
@@ -339,9 +295,8 @@ pub enum UnifiedData {
 }
 ```
 
-## also update with UnifiedData enumeration
-This list is not exhaustive; all previously `serialised bytes`
-need to be updated to a `UnifiedData`.
+## Update with UnifiedData enumeration
+This list is not exhaustive; all previously `serialised bytes` need to be updated to a `UnifiedData`:
 
 - `NameTypeAndId`
 - `MessageAction`

--- a/implemented/0001-Use-public-key-for-id-on-all-messages/0001-Use-public-key-for-id-on-all-messages.md
+++ b/implemented/0001-Use-public-key-for-id-on-all-messages/0001-Use-public-key-for-id-on-all-messages.md
@@ -10,7 +10,7 @@ At the moment client Id packets are created and a hash of these packets used as 
 
 As the network must confirm a client has paid the network, either by providing resource or via a network token (i.e. safecoin). Then it needs to look up the clients public key and confirm the signature of requests come from that client. This is done by querying the client ID (Hash), then looking up the ID packet and downloading it to get the public key.
 
-As such this requires an initial unauthorised `put` as the client is not known to the network and cannot be recognised without this. This means essentially the network has to allow unlited `Put` of client Id packets, thereby exposing a risk of wasted network usage.
+As such this requires an initial unauthorised `Put` as the client is not known to the network and cannot be recognised without this. This means essentially the network has to allow unlited `Put` of client Id packets, thereby exposing a risk of wasted network usage.
 
 This proposal removes all of this indirection and instead allows the client to be recognised by the public key included in messages or data types. Such messages and data types will be signed by the `secret key` that is paired with this public key. As only the owner should have access to this `secret key` then it can be assumed the message or request to mutate data is indeed valid in a cryptographically secure manner.
 
@@ -22,21 +22,13 @@ This mechanism does not reduce the total number of clients or types of clients a
 
 # Detailed design
 
-As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the `ClientManager` type persona (`MaidManager` in the case of data). These requests are signed and include the clients `PublicKey`. This public key can be allocated for, or matched to an existing, client account. The ClientManager may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key.
+As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the `ClientManager` type persona (`MaidManager` in the case of data). These requests are signed and include the clients `PublicKey`. This public key can be allocated for, or matched to an existing, client account. The `ClientManager` may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key.
 
-If a client wishes to amend any data (structured data) then this is already signed by that client and contains the
-`PublicKey` The client will sign the request to alter the data (by overwriting with a new valid one) and again
-the public key of the signed message is included in the message, confirming what key made the request. This key
-can then be confirmed to be one of the owners of the `StructuredData` element and if multiple owners
-then the signatures of the data element being uploaded is checked against the list of signatures of the new chunk
-using the owners keys of the last chunk.
+If a client wishes to amend any data (structured data) then this is already signed by that client and contains the `PublicKey`. The client will sign the request to alter the data (by overwriting with a new valid one) and again the public key of the signed message is included in the message, confirming what key made the request. This key can then be confirmed to be one of the owners of the `StructuredData` element and if it has multiple owners then the signatures of the data element being uploaded is checked against the list of signatures of the new chunk using the owners keys of the last chunk.
 
-Clients may identify themselves using the public key as their node address. Signing the request to join the network
-at that address. This is a different size key from routing nodes though, which is a benefit as it distinguishes these
-connections more clearly. This does require a change to the routing API to accommodate 32 byte node identities.
+Clients may identify themselves using the public key as their node address by signing the request to join the network at that address. This is a different size key from routing nodes though, which is a benefit as it distinguishes these connections more clearly. This does require a change to the routing API to accommodate 32 byte node identities.
 
-Clients themselves no longer will require to store Id's packets on the network (although they can via StructuredData).
-`PublicId` types are no longer required in the maidsafe_types library (maidsafe_client exclusive now).
+Clients themselves no longer will require to store Id's packets on the network (although they can via `StructuredData`). `PublicId` types are no longer required in the maidsafe_types library (maidsafe_client exclusive now).
 
 # Drawbacks
 

--- a/implemented/0001-Use-public-key-for-id-on-all-messages/0001-Use-public-key-for-id-on-all-messages.md
+++ b/implemented/0001-Use-public-key-for-id-on-all-messages/0001-Use-public-key-for-id-on-all-messages.md
@@ -6,43 +6,23 @@
 
 # Summary
 
-At the moment client Id packets are created and a hash of these packets used as identity.
-This is stored on the network as a `key` (ie the hash) / `value` (the public key) pair.
-These packets have to be available prior to the client storing data onto the network.
+At the moment client Id packets are created and a hash of these packets used as identity. This is stored on the network as a `key` (ie the hash) / `value` (the public key) pair. These packets have to be available prior to the client storing data onto the network.
 
-As the network must confirm a client has paid the network, either by providing resource
-or via a network token (i.e. safecoin). Then it needs to look up the clients public key
-and confirm the signature of requests come from that client. This is done by querying
-the client ID (Hash), then looking up the ID packet and downloading it to get the public key.
+As the network must confirm a client has paid the network, either by providing resource or via a network token (i.e. safecoin). Then it needs to look up the clients public key and confirm the signature of requests come from that client. This is done by querying the client ID (Hash), then looking up the ID packet and downloading it to get the public key.
 
-As such this requires an initial `unauthorised put` as the client is not known to the
-network and cannot be recognised without this. This means essentially the network has to
-allow unlited `Put` of client Id packets, thereby exposing a risk of wasted network usage.
+As such this requires an initial unauthorised `put` as the client is not known to the network and cannot be recognised without this. This means essentially the network has to allow unlited `Put` of client Id packets, thereby exposing a risk of wasted network usage.
 
-This proposal removes all of this indirection and instead allows the client to be recognised
-by the public key included in messages or data types. such messages and data types will be
-signed by the `secret key` that is paired with this public key. As only the owner should have
-access to this `secret key` then it can be assumed the message or request to mutate data is
-indeed valid in a cryptographically secure manner.
+This proposal removes all of this indirection and instead allows the client to be recognised by the public key included in messages or data types. Such messages and data types will be signed by the `secret key` that is paired with this public key. As only the owner should have access to this `secret key` then it can be assumed the message or request to mutate data is indeed valid in a cryptographically secure manner.
 
 # Motivation
 
-Storing Id packets is a strain on the network. Lookups are a strain and will slow down
-network actions. Id packets themselves may be a security issue (can they be hacked), although
-highly unlikely, it is impossible to hack if they do not exist!
+Storing Id packets is a strain on the network. Lookups are a strain and will slow down network actions. Id packets themselves may be a security issue (can they be hacked), although highly unlikely, it is impossible to hack if they do not exist!
 
-This mechanism does not reduce the total number of clients or types of clients as they all exist
-in an address space of 2^256 and app developers can use multiple Id's in very clever ways, such
-as the SAFE network does not distinguish between public id's and private id's. Now these and more are possible.
-Id's could be created to share data types (as co-owners) and allow shares access and write capability
-between applications and groups.
+This mechanism does not reduce the total number of clients or types of clients as they all exist in an address space of 2^256 and app developers can use multiple Id's in very clever ways, such as the SAFE network does not distinguish between public id's and private id's. Now these and more are possible. Id's could be created to share data types (as co-owners) and allow shares access and write capability between applications and groups.
 
 # Detailed design
 
-As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the
-ClientManager type persona (MaidManager in the case of data). These requests are signed and include the
-clients `PublicKey`. This public key can be allocated, or matched to an existing,to a client account.
-The ClientManager may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key.
+As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the `ClientManager` type persona (`MaidManager` in the case of data). These requests are signed and include the clients `PublicKey`. This public key can be allocated for, or matched to an existing, client account. The ClientManager may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key.
 
 If a client wishes to amend any data (structured data) then this is already signed by that client and contains the
 `PublicKey` The client will sign the request to alter the data (by overwriting with a new valid one) and again

--- a/implemented/0002-name-service/0002-name-service.md
+++ b/implemented/0002-name-service/0002-name-service.md
@@ -12,8 +12,7 @@ This data includes, long name (could be real name is users wish), web site id, b
 
 # Motivation
 
-In networks people expect to be able to lookup services related to names. In the SAFE network this includes the ability to retrieve public keys to encrypt data to that id, in cases where privacy is a requirement (e.g. in SAFE all messages are encrypted between identities). The opportunity for people to create and link web sites
-and other services is also a motivation for implementing such a system.
+In networks people expect to be able to lookup services related to names. In the SAFE network this includes the ability to retrieve public keys to encrypt data to that id, in cases where privacy is a requirement (e.g. in SAFE all messages are encrypted between identities). The opportunity for people to create and link web sites and other services is also a motivation for implementing such a system.
 
 # Detailed design
 
@@ -28,7 +27,7 @@ This is a simple use case for `Unified Structured Data` (see RFC 0000). In this 
 ```rust
 struct dns {
   long_name: String
-  encrytion_key: crypto::encrypt::public_key
+  encryption_key: crypto::encrypt::public_key
   //      service, location
   HashMap<String, (NameType, u64, bool, bool)> // As Directories are identified by a tuple of 4 parameters (NameType, tag, if private/encrypted, if versioned) it makes sense to have the 4 identifies stored for better scalability.
 }

--- a/implemented/0002-name-service/0002-name-service.md
+++ b/implemented/0002-name-service/0002-name-service.md
@@ -6,20 +6,14 @@
 
 # Summary
 
-In the current Internet Domains are referenced via a naming system which comprises an indexing mechanism
-This indexing mechanism is centralised and controlled, with the ability for countries and ISPs to switch it off
-pollute data with advertising data and much worse. The SAFE network on the other had offers a 'free (as in beer)'
-mechanism to locate data linked to a name. This proposal outlines a mechanism to look up data related to any name.
+In the current Internet Domains are referenced via a naming system which comprises an indexing mechanism. This indexing mechanism is centralised and controlled, with the ability for countries and ISPs to switch it off, pollute data with advertising data and much worse. The SAFE network on the other had offers a 'free (as in beer)' mechanism to locate data linked to a name. This proposal outlines a mechanism to look up data related to any name.
 
-This data includes, long name (could be real name is users wish), web site id, blog id, micro-blog id and may be 
-extended to include additional information as the network develops. 
+This data includes, long name (could be real name is users wish), web site id, blog id, micro-blog id and may be extended to include additional information as the network develops.
 
 # Motivation
 
-In networks people expect to be able to lookup services related to names. In the SAFE network this includes
-the ability to retrieve public keys to encrypt data to that id, in cases where privacy is a requirement (.e.
-in SAFE all messages are encrypted between identities). The opportunity for people to create and link web sites
-and other services is also a motivation for implementing such a system. 
+In networks people expect to be able to lookup services related to names. In the SAFE network this includes the ability to retrieve public keys to encrypt data to that id, in cases where privacy is a requirement (e.g. in SAFE all messages are encrypted between identities). The opportunity for people to create and link web sites
+and other services is also a motivation for implementing such a system.
 
 # Detailed design
 
@@ -27,24 +21,24 @@ This is a simple use case for `Unified Structured Data` (see RFC 0000). In this 
 
 1. The `type_tag` shall be type `4`
 
-2. The `Identity` shall be the `Sha512` of the publicly chosen name (user chooses this name)
+2. The `Identity` shall be the `SHA512` of the publicly chosen name (user chooses this name)
 
 3. The `data` field:
 
 ```rust
 struct dns {
-long_name: String
-encrytion_key: crypto::encrypt::public_key
-//      service, location
-HashMap<String, (NameType, u64, bool, bool)> // As Directories are identified by a tuple of 4 parameters (NameType, tag, if private/encrypted, if versioned) it makes sense to have the 4 identifies stored for better scalability.
+  long_name: String
+  encrytion_key: crypto::encrypt::public_key
+  //      service, location
+  HashMap<String, (NameType, u64, bool, bool)> // As Directories are identified by a tuple of 4 parameters (NameType, tag, if private/encrypted, if versioned) it makes sense to have the 4 identifies stored for better scalability.
 }
-
-Initially this `HashMap` will likely contain www, blog and micro-blog. Application developers may add services to enhance 
-users experiences with new applications and functions via this mechanism. 
-
 ```
 
-This is very likely to extend as the services on the network grows. 
+
+Initially this `HashMap` will likely contain "www", "blog" and "micro-blog". Application developers may add services to enhance
+users experiences with new applications and functions via this mechanism.
+
+This is very likely to extend as the services on the network grows.
 
 To find this information an application will `Hash(Hash(public_name) + type_tag))` and retrieve this packet.
 
@@ -54,13 +48,10 @@ None found at this time.
 
 # Alternatives
 
-Alternatives could be clients, passing this information via a series of messages, but this requires both parties
-being on-line or able to wait for each other to come on line.
+Alternatives could be clients, passing this information via a series of messages, but this requires both parties being online or able to wait for each other to come online.
 
 # Unresolved questions
 
-1. Should this struct contain the actual public_name (handle) as this may allow some indexing mechanism, which is
-prevented with this design (on purpose).
+1. Should this struct contain the actual public_name (handle) as this may allow some indexing mechanism, which is prevented with this design (on purpose).
 
-2. This prevents two identities using the same name, is this really the best way to go. This is more like twitter
-than facebook in approach. 
+2. This prevents two identities using the same name, is this really the best way to go. This is more like twitter than facebook in approach.

--- a/implemented/0002-name-service/0002-name-service.md
+++ b/implemented/0002-name-service/0002-name-service.md
@@ -23,7 +23,7 @@ and other services is also a motivation for implementing such a system.
 
 # Detailed design
 
-This is a simple use case for `Unified Structured Data` (see RFC XXXX). In this case we require to set three items
+This is a simple use case for `Unified Structured Data` (see RFC 0000). In this case we require to set three items
 
 1. The `type_tag` shall be type `4`
 

--- a/implemented/0003-reserved_names/0003-reserved_names.md
+++ b/implemented/0003-reserved_names/0003-reserved_names.md
@@ -10,9 +10,7 @@ A very simple RFC to outline and maintain (over time) a known list of `type_tags
 
 # Motivation
 
-As with `IANA` type registries or indeed the common well known service ports found in many Operating Systems (OSs)
-this list will allow applications that achieve the happy position of being commonplace, or extremely popular to 
-register their `type_tag` in this file. This allows other application developers to choose a non registered tag to
+As with `IANA` type registries or indeed the common well known service ports found in many Operating Systems (OSs) this list will allow applications that achieve the happy position of being commonplace, or extremely popular to  register their `type_tag` in this file. This allows other application developers to choose a non registered tag to
 reduce any confusion or name collisions (although the latter is extremely improbable, given the address space).
 
 # Detailed design
@@ -37,8 +35,7 @@ reduce any confusion or name collisions (although the latter is extremely improb
 
 10,001-(2^64 - 1)  --      Available
 
-The numbers 0-10,000 will be hard coded into vaults for the use of the core network only and will not be likely
-available to application developers to overwrite their structure.
+The numbers 0-10,000 will be hard coded into vaults for the use of the core network only and will not be likely available to application developers to overwrite their structure.
 
 # Drawbacks
 

--- a/implemented/0019-new-kademlia-routing-logic/0019-new-kademlia-routing-logic.md
+++ b/implemented/0019-new-kademlia-routing-logic/0019-new-kademlia-routing-logic.md
@@ -8,9 +8,7 @@
 
 # Summary
 
-The current mechanism implemented in the [kademlia_routing_table][1] and
-[routing][2] crates has several weaknesses that lead to potential problems
-affecting security, performance and even basic functionality.
+The current mechanism implemented in the [kademlia_routing_table][1] and [routing][2] crates has several weaknesses that lead to potential problems affecting security, performance and even basic functionality.
 
 [1]: https://github.com/maidsafe/kademlia_routing_table
 [2]: https://github.com/maidsafe/routing
@@ -20,61 +18,30 @@ affecting security, performance and even basic functionality.
 
 In the current implementation,
 
-* routing table entries are symmetric, i. e. I can't be in your table if you are
-  not in mine,
-* the routing crate does not add enough connections to a new nodes' table to
-  ensure the [invariant required for Kademlia](http://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf)
-  (3rd paragraph in "System description"),
-* the `kademlia_routing_table::RoutingTable`'s methods to choose desired entries
-  do not ensure the invariant, even if presented with enough potential entries,
-* not even the original Kademlia invariant is strong enough to guarantee that
-  messages reach every member of a target's close group, or that every node
-  knows whether it is a member of that group,
-* the parallelism feature makes the upper bound for the number of hop messages
-  that are sent for a single message grow linearly with the network size,
-  instead of logarithmically,
-* the parallelism feature causes hop messages to be sent to messages outside the
-  target's bucket, which does not reduce the estimate for the remaining number
-  of hops to the target.
+* routing table entries are symmetric, i. e. I can't be in your table if you are not in mine,
+* the routing crate does not add enough connections to a new nodes' table to ensure the [invariant required for Kademlia](http://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf) (3rd paragraph in "System description"),
+* the `kademlia_routing_table::RoutingTable`'s methods to choose desired entries do not ensure the invariant, even if presented with enough potential entries,
+* not even the original Kademlia invariant is strong enough to guarantee that messages reach every member of a target's close group, or that every node knows whether it is a member of that group,
+* the parallelism feature makes the upper bound for the number of hop messages that are sent for a single message grow linearly with the network size, instead of logarithmically,
+* the parallelism feature causes hop messages to be sent to messages outside the target's bucket, which does not reduce the estimate for the remaining number of hops to the target.
 
-Some of these issues have already been demonstrated in tests: Both the routing
-crate's ci_test and deployed test networks have shown that the routing tables
-are insufficiently filled, and
-[tests for the kademlia_routing_table](https://github.com/afck/kademlia_routing_table/blob/network_tests/src/lib.rs#L1308)
-crate show that even under ideal conditions, messages do not always reach their
-target and the number of nodes that consider themselves members of a particular
-close group can exceed 100 - orders of magnitude above the current group size of
-8.
+Some of these issues have already been demonstrated in tests: Both the `routing` crate's ci_test and deployed test networks have shown that the routing tables are insufficiently filled, and
+[tests for the kademlia_routing_table](https://github.com/afck/kademlia_routing_table/blob/network_tests/src/lib.rs#L1308) crate show that even under ideal conditions, messages do not always reach their target. And finally the number of nodes that consider themselves members of a particular close group can exceed 100 - orders of magnitude above the current group size of 8.
 
-Of course a peer-to-peer network has to deal with lots of unpredictable
-problems, like malicious nodes, simultaneously joining or leaving nodes,
-connection failures, etc., so no absolute guarantees can be made. However,
-we can expect to have proof that at least in the most common scenarios (e. g.
-one node leaves, then there is some time to adapt to the change, then a message
-is sent) the routing mechanism *does* make the guarantees that its users rely
-on.
+Of course a peer-to-peer network has to deal with lots of unpredictable problems, like malicious nodes, simultaneously joining or leaving nodes, connection failures, etc., so no absolute guarantees can be made. However, we can expect to have proof that at least in the most common scenarios (e. g. one node leaves, then there is some time to adapt to the change, then a message is sent) the routing mechanism *does* make the guarantees that its users rely on.
 
-Instead of detailing how and where the above points fail, this is a proposal to
-make some changes to the routing logic, together with a rigorous argument why
-this will make the following guarantees in common scenarios:
+Instead of detailing how and where the above points fail, this is a proposal to make some changes to the routing logic, together with a rigorous argument why this will make the following guarantees in common scenarios:
 
 
 ## Guaranteed properties
 
-1. The number of nodes in the network with `node.is_close(target) == true` is
-   exactly `GROUP_SIZE` for each target address.
-2. Each node in a given address' close group is connected to each other node in
-   that group. In particular, every node is connected to its own close group.
-3. Each message reaches every member of the destination's close group after at
-   most 512 hops.
-4. The number of total hop messages created for each message is at most
-   `PARALLELISM * 512`.
-5. For each node there are at most 512 * `GROUP_SIZE` other nodes in the network
-   for which it can obtain the IP address, at any point in time.
+1. The number of nodes in the network with `node.is_close(target) == true` is exactly `GROUP_SIZE` for each target address.
+2. Each node in a given address' close group is connected to each other node in that group. In particular, every node is connected to its own close group.
+3. Each message reaches every member of the destination's close group after at most 512 hops.
+4. The number of total hop messages created for each message is at most `PARALLELISM * 512`.
+5. For each node there are at most 512 * `GROUP_SIZE` other nodes in the network for which it can obtain the IP address, at any point in time.
 
-**TODO**: We should add more guarantees here, e. g.: If `PARALLELISM - 1` nodes
-suddenly go offline and routing tables haven't been updated yet, messages still
-reach their destination. Or: If two nodes are unable to directly connect to each
+**TODO**: We should add more guarantees here, e. g.: If `PARALLELISM - 1` nodes suddenly go offline and routing tables haven't been updated yet, messages still reach their destination. Or: If two nodes are unable to directly connect to each
 other, ... etc.
 
 
@@ -85,302 +52,164 @@ The network will attempt to always satisfy the following invariant:
 
 ## The invariant
 
-In every node, every bucket is maximally filled, and every node knows its close
-group. That means:
+In every node, every bucket is maximally filled, and every node knows its close group. That means:
 
-Whenever a bucket has less than `BUCKET_SIZE` entries, it contains *all nodes in
-the network* that have the corresponding bucket distance.
+Whenever a bucket has less than `BUCKET_SIZE` entries, it contains *all nodes in the network* that have the corresponding bucket distance.
 
 
 ## Changes to the routing logic
 
-In kademlia_routing_table:
+In `kademlia_routing_table`:
 
-* The constants are changed and a test asserts that `BUCKET_SIZE == GROUP_SIZE`
-  and `BUCKET_SIZE >= PARALLELISM`. (Possibly remove `BUCKET_SIZE`.)
-* I am allowed to connect to you (and learn about your IP address) if and only
-  if you are in the close group of one of my *bucket address*es: an address that
-  differs from mine in exactly one bit, (independent of whether you want me in
-  your routing table). A new `allow_connection` method will check that.
-* The `add_node` and `want_to_add` methods are modified so that we always
-  add/want a node if its bucket does not yet have `BUCKET_SIZE` entries.
+* The constants are changed and a test asserts that `BUCKET_SIZE == GROUP_SIZE` and `BUCKET_SIZE >= PARALLELISM`. (Possibly remove `BUCKET_SIZE`.)
+* I am allowed to connect to you (and learn about your IP address) if and only if you are in the close group of one of my *bucket address*es: an address that differs from mine in exactly one bit, (independent of whether you want me in your routing table). A new `allow_connection` method will check that.
+* The `add_node` and `want_to_add` methods are modified so that we always add/want a node if its bucket does not yet have `BUCKET_SIZE` entries.
 * Don't automatically drop nodes from the routing table when adding new ones.
-* The `target_nodes` function is modified (and used in routing accordingly) so
-  that only the source node of a message sends `PARALLELISM` copies of it.
+* The `target_nodes` function is modified (and used in routing accordingly) so that only the source node of a message sends `PARALLELISM` copies of it.
 * Apart from that, each node relays every copy of the message that it receives,
   and up to `PARALLELISM` copies.
-* As an exception to the previous point: Any message sent to a group that the
-  current node belongs to is relayed to the `GROUP_SIZE - 1` nodes closest to
-  the target.
-* The `is_close` method returns whether there are fewer than `GROUP_SIZE` nodes
-  in the routing table which are closer to the target than `self`.
+* As an exception to the previous point: Any message sent to a group that the current node belongs to is relayed to the `GROUP_SIZE - 1` nodes closest to the target.
+* The `is_close` method returns whether there are fewer than `GROUP_SIZE` nodes in the routing table which are closer to the target than `self`.
 
 In routing:
 
-* Whenever a node joins or leaves, all routing tables are updated so that the
-  invariant is satisfied. (See below for details.)
-* Raise churn events if the lost or new node belongs to *any* close group that
-  we are a member of, not just *our* close group. (See below.)
+* Whenever a node joins or leaves, all routing tables are updated so that the invariant is satisfied. (See below for details.)
+* Raise churn events if the lost or new node belongs to *any* close group that we are a member of, not just *our* close group. (See below.)
 
-See the appendix below for proofs that the invariant and these changes will
-guarantee the desired properties.
+See the appendix below for proofs that the invariant and these changes will guarantee the desired properties.
 
 
 ## Node insertion
 
-After adding its close group to the routing table, a new node knows that only
-the buckets up to the first one that currently has an entry can potentially have
-entries. (Nodes in later buckets would belong to the close group!) For each such
-bucket `i` that is not full (i. e. has `GROUP_SIZE` entries) yet, the node sends
-a `GetCloseGroup` request to the `NaeManager` of its `i`-th bucket address.
+After adding its close group to the routing table, a new node knows that only the buckets up to the first one that currently has an entry can potentially have entries. (Nodes in later buckets would belong to the close group!) For each such
+bucket `i` that is not full (i. e. has `GROUP_SIZE` entries) yet, the node sends a `GetCloseGroup` request to the `NaeManager` of its `i`-th bucket address.
 
-The group verifies that it is one the sender's bucket addresses and the sender
-is therefore allowed to connect to its members. It responds with the groups'
-public IDs to the new node. The node then exchanges its endpoints with each of
-the members and establishes the connections.
+The group verifies that it is one the sender's bucket addresses and the sender is therefore allowed to connect to its members. It responds with the groups' public IDs to the new node. The node then exchanges its endpoints with each of the members and establishes the connections.
 
-At that point, the invariant holds true for the new node's routing table. But it
-might still fail at another node `n` with bucket index `i`, whose `i`-th bucket
-is not full.
+At that point, the invariant holds true for the new node's routing table. But it might still fail at another node `n` with bucket index `i`, whose `i`-th bucket is not full.
 
-This can only happen if there were less than `GROUP_SIZE` nodes `m` in the
-network before that had `bi(n, m) == i`. If such nodes exist, then some of them
-have just connected to the new node and they know that their `i`-th bucket was
-not full before.
+This can only happen if there were less than `GROUP_SIZE` nodes `m` in the network before that had `bi(n, m) == i`. If such nodes exist, then some of them have just connected to the new node and they know that their `i`-th bucket was not full before.
 
-So whenever a node `n` adds a new node to a bucket `i` that was not full, `n`
-needs to make sure that *all* nodes `m` in the network with `bi(m, n) > i` are
-notified. To do that, it sends a `Churn` message to *all* entries from its
-`i + 1`-th bucket onwards. Since all nodes that receive the event do the same,
-this will reach every node with `bi(m, n) > i`. (In a balanced network with an
-even distribution of addresses, this should rarely be substantially more than
-`GROUP_SIZE` nodes.)
+So whenever a node `n` adds a new node to a bucket `i` that was not full, `n` needs to make sure that *all* nodes `m` in the network with `bi(m, n) > i` are notified. To do that, it sends a `Churn` message to *all* entries from its `i + 1`-th bucket onwards. Since all nodes that receive the event do the same,
+this will reach every node with `bi(m, n) > i`. (In a balanced network with an even distribution of addresses, this should rarely be substantially more than `GROUP_SIZE` nodes.)
 
 
 ## Node removal
 
-Since we keep connections open to each routing table entry, every contact of a
-leaving node learns about the removal. (Should we change that, a periodic check
-needs to be introduced.)
+Since we keep connections open to each routing table entry, every contact of a leaving node learns about the removal. (Should we change that, a periodic check needs to be introduced.)
 
-If a node loses a connection in a bucket that is not full, no action needs to
-be taken: Because of the invariant, the remaining nodes in that bucket are *all*
-there are in the network with the given bucket index.
+If a node loses a connection in a bucket that is not full, no action needs to be taken: Because of the invariant, the remaining nodes in that bucket are *all* there are in the network with the given bucket index.
 
-If the bucket was full before, the entry probably needs to be replaced. To do
-that, the node sends another `GetPublicIdWithEndpoints` request to the bucket
-address of the modified bucket, as if it had just joined, to obtain the contact
-information of the *new* close group of its `i`-th bucket and refill it.
+If the bucket was full before, the entry probably needs to be replaced. To do that, the node sends another `GetPublicIdWithEndpoints` request to the bucket address of the modified bucket, as if it had just joined, to obtain the contact information of the *new* close group of its `i`-th bucket and refill it.
 
 
 ## Churn
 
-If a node is joining or leaving, the upper layers are informed about it so that
-they can adapt to the change in the network, e. g. restore the desired
-replication number of data chunks. The nodes that need to act on this are those
-which are in any close group together with the new/lost node.
+If a node is joining or leaving, the upper layers are informed about it so that they can adapt to the change in the network, e. g. restore the desired replication number of data chunks. The nodes that need to act on this are those which are in any close group together with the new/lost node.
 
-If the new/lost node `n` is/was in any non-full bucket, this is the case:
-We and the lost node are then both close to that bucket address.
+If the new/lost node `n` is/was in any non-full bucket, this is the case: We and the lost node are then both close to that bucket address.
 
-If the bucket `i` is full, then we are not close to any address that disagrees
-with us in the `i`-th place, so the question is whether `n` is close to any
-other address we are close to. If we have `GROUP_SIZE - 1` or more contacts with
-higher indices, this is not the case: These would all be closer than `n`.
-Otherwise it *is* the case: Ourselves and `n` are in the close group of `n`'s
+If the bucket `i` is full, then we are not close to any address that disagrees with us in the `i`-th place, so the question is whether `n` is close to any other address we are close to. If we have `GROUP_SIZE - 1` or more contacts with higher indices, this is not the case: These would all be closer than `n`. Otherwise it *is* the case: Ourselves and `n` are in the close group of `n`'s
 `i`-th bucket address.
 
-So a `Churn` event needs to be raised if `n` is in a non-full bucket or we have
-less than `GROUP_SIZE - 1` contacts with a bucket index greater than `n`'s.
+So a `Churn` event needs to be raised if `n` is in a non-full bucket or we have less than `GROUP_SIZE - 1` contacts with a bucket index greater than `n`'s.
 
 
 # Drawbacks
 
-The expected routing table size for a network with 2<sup>n</sup> nodes will be
-about `GROUP_SIZE * n`. Each of these entries currently corresponds to at least
-one open connection and two threads. It would therefore be desirable to reduce
-the routing table size.
+The expected routing table size for a network with `2ⁿ` nodes will be about `GROUP_SIZE * n`. Each of these entries currently corresponds to at least one open connection and two threads. It would therefore be desirable to reduce the routing table size.
 
 
 # Unresolved questions
 
-The idea behind group authorities (close groups) as well as parallelism (sending
-the message along more than one path) is to provide security and redundancy.
-However, the former measure can easily bypassed if the latter is undermined:
-A single node could invent a whole close group and claim that it is relaying
-messages from them. The recipient usually doesn't know the sender: They neither
-know their public keys, nor do they know the network layout around the sender,
-so they don't know whether the sender actually *is* close to the source address,
-nor whether the sender is a legitimate node at all.
+The idea behind group authorities (close groups) as well as parallelism (sending the message along more than one path) is to provide security and redundancy. However, the former measure can easily bypassed if the latter is undermined: A single node could invent a whole close group and claim that it is relaying messages from them. The recipient usually doesn't know the sender: They neither know their public keys, nor do they know the network layout around the sender, so they don't know whether the sender actually *is* close to the source address, nor whether the sender is a legitimate node at all.
 
-One idea to prevent this kind of attack would rely on the parallel paths of a
-message never intersecting:
+One idea to prevent this kind of attack would rely on the parallel paths of a message never intersecting:
 
-* Every hop node signs the public key of the previous node: They have them in
-their routing table and know that it's a legitimate node, in the sense that it
-was added to the network via the bootstrap procedure. All these keys and
-signatures are passed along with the message until it reaches its destination.
-* Every copy of a message except the first one is *bounced back* to the previous
-hop node, and that tries to route it via another contact. That way the
-`PARALLELISM` copies of the message will have taken four completely different
-routes to the target.
+* Every hop node signs the public key of the previous node: They have them in their routing table and know that it's a legitimate node, in the sense that it was added to the network via the bootstrap procedure. All these keys and signatures are passed along with the message until it reaches its destination.
+* Every copy of a message except the first one is *bounced back* to the previous hop node, and that tries to route it via another contact. That way the `PARALLELISM` copies of the message will have taken four completely different routes to the target.
 
-The target node then has `PARALLELISM` uninterrupted chains of signatures: I
-know A and A signed B and B signed C and C sent the message. For the
-message to be faked, *each* of these paths would have to contain one of the
-attacker's nodes.
+The target node then has `PARALLELISM` uninterrupted chains of signatures: I know A and A signed B and B signed C and C sent the message. For the message to be faked, *each* of these paths would have to contain one of the attacker's nodes.
 
-By making `PARALLELISM` big enough this might make attacks infeasible. (If the
-attacker controls a percentage `a` of a network with `2`<sup>`n`</sup> nodes,
-the chance to intercept any given path of length `n` is about
-`1 - (1 - a)`<sup>`n`</sup>, and the chance to intercept *all* `p = PARALLELISM`
-paths is about `(1 - (1 - a)`<sup>`n`</sup>`)`<sup>`p`</sup>. E. g. in a
-network with a million nodes (`n = 20`) and `p = 8`, an attacker who controls
-`a = 5%` of the nodes would still have a chance of success of about `3%`.)
+By making `PARALLELISM` big enough this might make attacks infeasible: If the attacker controls a percentage `a` of a network with `2ⁿ` nodes, the chance to intercept any given path of length `n` is about `1 - (1 - a)ⁿ`, and the chance to intercept *all* `p = PARALLELISM` paths is about `(1 - (1 - a)ⁿ)ᵖ`. E. g. in a network with a million nodes (`n = 20`) and `p = 8`, an attacker who controls 5% of nodes (`a = 5%`, 50.000 nodes) would still have a chance of success of about `3%`.
 
-Maybe there are ways to change the routing algorithm so that the paths of the
-copies usually stay disjoint by themselves, so that too many bounces can be
-avoided? A few wild ideas:
+Maybe there are ways to change the routing algorithm so that the paths of the copies usually stay disjoint by themselves, so that too many bounces can be avoided? A few wild ideas:
 
-* A copy could be numbered from the beginning, and copy `n` could always be
-routed via the `n`-th closest node to the target, instead of the closest one.
-This might make it likely, but not impossible, that the paths never collide.
-(We will need to count bounces in tests to verify that, probably also using
-a highly imbalanced network to simulate one path in a very large network.)
-* Nodes could have one of `GROUP_SIZE` colours. A close group consists of one
-node in each colour: the single closest node to the target with that colour.
-Every message copy is routed via a path that stays exclusively in one colour,
-until it reaches the destination, making it *impossible* for the copies to
-collide. This would change the routing algorithm considerably: Instead of one
-table with bucket size `GROUP_SIZE`, each node would have to keep `GROUP_SIZE`
-tables - one for each colour - with bucket size 1.
+* A copy could be numbered from the beginning, and copy `n` could always be routed via the `n`-th closest node to the target, instead of the closest one. This might make it likely, but not impossible, that the paths never collide. (We will need to count bounces in tests to verify that, probably also using a highly imbalanced network to simulate one path in a very large network.)
+* Nodes could have one of `GROUP_SIZE` colours. A close group consists of one node in each colour: the single closest node to the target with that colour. Every message copy is routed via a path that stays exclusively in one colour, until it reaches the destination, making it *impossible* for the copies to collide. This would change the routing algorithm considerably: Instead of one table with bucket size `GROUP_SIZE`, each node would have to keep `GROUP_SIZE` tables - one for each colour - with bucket size 1.
 
 
 # Alternatives
 
-If the routing table size turns out to be too large in practice, we could let
-connections time out: Entries we haven't communicated with within some period of
-time are disconnected, without being removed from the routing table. The
-connection is reestablished periodically to check whether the node is still
-there, as well as whenever we need to route messages via them. This should allow
-us to keep only `PARALLELISM` connections open per bucket most of the time.
+If the routing table size turns out to be too large in practice, we could let connections time out: Entries we haven't communicated with within some period of time are disconnected, without being removed from the routing table. The
+connection is reestablished periodically to check whether the node is still there, as well as whenever we need to route messages via them. This should allow us to keep only `PARALLELISM` connections open per bucket most of the time.
 
-We could also experiment with smaller values for `GROUP_SIZE` and `PARALLELISM`,
-but we need to make sure that that doesn't compromise security.
+We could also experiment with smaller values for `GROUP_SIZE` and `PARALLELISM`, but we need to make sure that that doesn't compromise security.
 
-Finally, if it turns out to be a problem that we never drop nodes (it shouldn't,
-because we are only allowed to add nodes that are close to one of our bucket
-addresses anyway), nodes could periodically send `IDontWantToTalkToYouAnymore`
-messages to every entry in an overflowing bucket except the `BUCKET_SIZE`
-closest ones to the bucket address. The other node then drops the connection if
-it also doesn't need it anymore.
+Finally, if it turns out to be a problem that we never drop nodes (it shouldn't, because we are only allowed to add nodes that are close to one of our bucket addresses anyway), nodes could periodically send `IDontWantToTalkToYouAnymore` messages to every entry in an overflowing bucket except the `BUCKET_SIZE` closest ones to the bucket address. The other node then drops the connection if it also doesn't need it anymore.
 
 
 # Appendix: Proofs
 
-We prove that whenever the invariant holds, the desired properties are
-guaranteed.
+We prove that whenever the invariant holds, the desired properties are guaranteed.
 
-Let `bd(x, y)` be the bucket distance between two addresses `x` and `y`, `x ^ y`
-the XOR distance, and `bi(x, y) = 512 - bd(x, y)` the bucket index.
-Equivalently, the `bi(x, y)`-th bit is the first (most significant) one where
-`x` and `y` disagree.
+Let `bd(x, y)` be the bucket distance between two addresses `x` and `y`, `x ^ y` the XOR distance, and `bi(x, y) = 512 - bd(x, y)` the bucket index. Equivalently, the `bi(x, y)`-th bit is the first (most significant) one where `x` and `y` disagree.
 
 
 ### Lemma 1
 
-`y` is XOR-closer to `x` than `z` if and only if `y` agrees with `x` in the most
-significant bit where `y` disagrees with `z`. That is, the following are
-equivalent:
+`y` is XOR-closer to `x` than `z` if and only if `y` agrees with `x` in the most significant bit where `y` disagrees with `z`. That is, the following are equivalent:
 
 * `x ^ y < x ^ z`
 * `x` and `y` agree in the `bi(y, z)`-th bit.
 * `x` and `z` disagree in the `bi(y, z)`-th bit.
 
 **Proof:**
-`x ^ y < x ^ z` means that in the most significant bit where `x ^ y` and
-`x ^ z` disagree, `x ^ y` has a 0. But `x ^ y` and `x ^ z` disagree in the same
-bits as `y` and `z`, i. e. they first disagree in the `bi(y, z)`-th bit.
-Since `x ^ y` has a 0 there, that means that `x` and `y` agree there.
-Similarly, since `x ^ z` is 1 in that place, `x` and `z` disagree there.
+`x ^ y < x ^ z` means that in the most significant bit where `x ^ y` and `x ^ z` disagree, `x ^ y` has a 0. But `x ^ y` and `x ^ z` disagree in the same bits as `y` and `z`, i. e. they first disagree in the `bi(y, z)`-th bit. Since `x ^ y` has a 0 there, that means that `x` and `y` agree there. Similarly, since `x ^ z` is 1 in that place, `x` and `z` disagree there.
 
 
 ### Lemma 2
 
-If `n` is in the close group to `d`, it has every node `m` in its routing table
-which is *even closer* to `d`.
+If `n` is in the close group to `d`, it has every node `m` in its routing table which is *even closer* to `d`.
 
 **Proof:**
-By Lemma 1, `m` is closer to `d` if and only if `d` and `n` agree in the
-`bi(m, n)`-th digit, i. e. if `m` would belong in a bucket `i` of `n` such that
-`d ^ n` has a `0` in the `i`-th position. In other words, the nodes closer to
-`d` than `n` are exactly those which belong in such a bucket. If there were
-`GROUP_SIZE` of them, `n` wouldn't be close to `d`, so there are less than
-`GROUP_SIZE` of them, which means none of these buckets is full. Therefore
-`m` is actually in one of those buckets of `n` because of the invariant.
+By Lemma 1, `m` is closer to `d` if and only if `d` and `n` agree in the `bi(m, n)`-th digit, i. e. if `m` would belong in a bucket `i` of `n` such that `d ^ n` has a `0` in the `i`-th position. In other words, the nodes closer to `d` than `n` are exactly those which belong in such a bucket. If there were `GROUP_SIZE` of them, `n` wouldn't be close to `d`, so there are less than
+`GROUP_SIZE` of them, which means none of these buckets is full. Therefore `m` is actually in one of those buckets of `n` because of the invariant.
 
 
 ### Property 1
 
-If a node is among the `GROUP_SIZE` closest nodes in the network, it cannot have
-`GROUP_SIZE` other, closer nodes in its routing table. Therefore `is_close`
-returns `true`.
+If a node is among the `GROUP_SIZE` closest nodes in the network, it cannot have `GROUP_SIZE` other, closer nodes in its routing table. Therefore `is_close` returns `true`.
 
-For the converse, assume there are `GROUP_SIZE` nodes that are closer to the
-target `t` than our node's address `n`. That such a node `c` is closer to `t`
-means `t ^ c < t ^ n`, which by Lemma 1 is equivalent to `c` belonging in the
-`i`-th bucket of `n` for some `i` such that `n` and `t` disagree in the `i`-th
-bit. Since by the invariant each such bucket contains either *all* nodes with
-that bucket distance or `GROUP_SIZE` such nodes, the routing table then has at
-least `GROUP_SIZE` such entries `c`.
+For the converse, assume there are `GROUP_SIZE` nodes that are closer to the target `t` than our node's address `n`. That such a node `c` is closer to `t` means `t ^ c < t ^ n`, which by Lemma 1 is equivalent to `c` belonging in the `i`-th bucket of `n` for some `i` such that `n` and `t` disagree in the `i`-th bit. Since by the invariant each such bucket contains either *all* nodes with that bucket distance or `GROUP_SIZE` such nodes, the routing table then has at least `GROUP_SIZE` such entries `c`.
 
 
 ### Property 2
 
-Let `n` and `m` be in the close group of `d`. Without loss of generality assume
-that `n` is closer to `d`. Then by Lemma 2, `m` has `n` in its routing table.
-Therefore, the two are connected.
-
+Let `n` and `m` be in the close group of `d`. Without loss of generality assume that `n` is closer to `d`. Then by Lemma 2, `m` has `n` in its routing table. Therefore, the two are connected.
 
 ### Property 3
 
-Thanks to property 2, we only have to show that the message reaches the node
-closest to the destination `d`, as from there it will directly be sent to all
-the other close nodes.
+Thanks to property 2, we only have to show that the message reaches the node closest to the destination `d`, as from there it will directly be sent to all the other close nodes.
 
-For that, we show that every node `n` that is not closest to `d` increases the
-number of *good* leading bits in the next hop:
+For that, we show that every node `n` that is not closest to `d` increases the number of *good* leading bits in the next hop:
 
-A bit `i` is *good* for `n` if either `n ^ x` is 0 in that bit, or `n`'s `i`-th
-bucket is empty.
+A bit `i` is *good* for `n` if either `n ^ x` is 0 in that bit, or `n`'s `i`-th bucket is empty.
 
-Let the current node `n` not be closest to the destination `d`, and assume that
-the first `i` bits are good. The message is sent to the entry `m` in `n`'s
-routing table which is closest to `d`, so we need to prove that `m` has at least
-`i + 1` good leading bits.
+Let the current node `n` not be closest to the destination `d`, and assume that the first `i` bits are good. The message is sent to the entry `m` in `n`'s routing table which is closest to `d`, so we need to prove that `m` has at least `i + 1` good leading bits.
 
-Since `m` minimizes the distance to `d` among the table entries, it must be in
-the first nonempty bucket `k` of `n` such that `n` and `d` disagree in the
-`k`-th bit. Thus the `k`-th is the first bit that is not good for `n`, that is,
-`k = i + 1`. Since `m` and `d` agree there, it is, however, good for `m`.
+Since `m` minimizes the distance to `d` among the table entries, it must be in the first non-empty bucket `k` of `n` such that `n` and `d` disagree in the `k`-th bit. Thus the `k`-th is the first bit that is not good for `n`, that is, `k = i + 1`. Since `m` and `d` agree there, it is, however, good for `m`.
 
-If we can show that the first `i` bits are also still good for `m`, then it
-follows that `m` has in fact at least `i + 1` good leading bits:
+If we can show that the first `i` bits are also still good for `m`, then it follows that `m` has in fact at least `i + 1` good leading bits:
 
-But `m` and `n` agree in the first `i` bits. So wherever `n ^ x` has a 0,
-`m ^ x` also does. Also, the nodes with bucket distance `j` for every `j <= i`
-are the same, so whenever `n`'s `j`-th bucket is empty, the invariant implies
-that there are no nodes with that bucket distance in the network and therefore
-`m`'s `j`-th bucket must also be empty.
+But `m` and `n` agree in the first `i` bits. So wherever `n ^ x` has a 0, `m ^ x` also does. Also, the nodes with bucket distance `j` for every `j <= i` are the same, so whenever `n`'s `j`-th bucket is empty, the invariant implies that there are no nodes with that bucket distance in the network and therefore `m`'s `j`-th bucket must also be empty.
 
 
 ### Property 4
 
-This follows immediately from Property 3, since only `PARALLELISM` different
-messages are created by the sender.
+This follows immediately from Property 3, since only `PARALLELISM` different messages are created by the sender.
 
 
 ### Property 5
 
-There are `512` bucket addresses, and each of them has only `GROUP_SIZE` close
-nodes.
+There are `512` bucket addresses, and each of them has only `GROUP_SIZE` close nodes.

--- a/implemented/0026-crust-mock/0026-crust-mock.md
+++ b/implemented/0026-crust-mock/0026-crust-mock.md
@@ -7,15 +7,11 @@
 
 # Summary
 
-Drop-in mock replacement for Crust to make it easier to unit test libraries and
-applications that use Crust.
+Drop-in mock replacement for Crust to make it easier to unit test libraries and applications that use Crust.
 
 # Motivation
 
-Testing Crust-depending libraries on real network (even on LAN or localhost) is
-cumbersome, slow and potentially expensive. A drop in mock replacement for Crust
-could make these test simpler and faster, make it easier to diagnose failures,
-and help cover edge cases difficult to set up on real network.
+Testing Crust-depending libraries on real network (even on LAN or localhost) is cumbersome, slow and potentially expensive. A drop in mock replacement for Crust could make these test simpler and faster, make it easier to diagnose failures, and help cover edge cases difficult to set up on real network.
 
 # Detailed design
 
@@ -23,16 +19,13 @@ This section details one possible implementation of the Crust Mock.
 
 ## Changes to routing
 
-Add a feature gate which when enabled will replace `crust::Service` with the mock
-version. There might be need to replace other types with mock version. One potential candiate is `crust::OutConnectionInfo`.
+Add a feature gate which when enabled will replace `crust::Service` with the mock version. There might be need to replace other types with mock version. One potential candidate is `crust::OutConnectionInfo`.
 
 ## Features of `crust::mock::Service`
 
 - Do not hit real network (not even LAN or localhost), do not use TCP/UDP sockets.
-- Simulate all the relevant config files crust uses (crust config, bootstrap cache, etc...). Possibly by accepting structs, representing those configs, as
-parameters to the constructor.
-- Pass simulated packets (messages) between different instances of
-the mock service.
+- Simulate all the relevant config files crust uses (crust config, bootstrap cache, etc...). Possibly by accepting structs, representing those configs, as parameters to the constructor.
+- Pass simulated packets (messages) between different instances of the mock service.
 - Enable, disable, pause and resume incoming and outgoing traffic for each `mock::Service` individually (and/or for the whole mock network), to simulate various network failures.
 - Full control over the order of the simulated network operations. The whole system SHOULD be synchronous.
 - OPTIONALLY: intercept and examine messages sent over the simulated network
@@ -62,14 +55,11 @@ Closest to actual usage, but very slow, unpredictable, potentially expensive and
 
 ## Testing on local network
 
-Faster than on real network, but getting sufficient number of physical machines
-might be expensive. Difficult to test connection failures and other error situations (as LANs tend to be more reliable than real networks).
-Still slow and cumbersome to diagnose.
+Faster than on real network, but getting sufficient number of physical machines might be expensive. Difficult to test connection failures and other error situations (as LANs tend to be more reliable than real networks). Still slow and cumbersome to diagnose.
 
 ## Testing on localhost
 
-Tricky to test large networks as they tent to exhaust hardware resources (CPU, RAM),
-making testing slow and unpredictable. Diagnosis is still slow and cumbersome.
+Tricky to test large networks as they tent to exhaust hardware resources (CPU, RAM), making testing slow and unpredictable. Diagnosis is still slow and cumbersome.
 
 ## Conditional compilation instead of trait
 


### PR DESCRIPTION
While trying to catch up on the RFCs, I noticed some contain typos, were hard to read (with an editor) or had some formatting differences (like unneeded wrapping or missing markup). This PR contains these fixes I made to the agreed and implemented RFCs. None of the fixes changes the actual content or meaning of any of RFCs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/rfcs/119)
<!-- Reviewable:end -->
