### PR TITLE
Headings

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -8,28 +8,28 @@
 - Supersedes: (fill me in with a link to RFC this supersedes - if applicable)
 - Superseded by: (fill me in with a link to RFC this is superseded by - if applicable)
 
-# Summary
+## Summary
 
 One paragraph explanation of the feature.
 
-# Motivation
+## Motivation
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-# Detailed design
+## Detailed design
 
 This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
 with the network to understand, and for somebody familiar with the code practices to implement.
 This should get into specifics and corner-cases, and include examples of how the feature is used.
 
-# Drawbacks
+## Drawbacks
 
 Why should we *not* do this?
 
-# Alternatives
+## Alternatives
 
 What other designs have been considered? What is the impact of not doing this?
 
-# Unresolved questions
+## Unresolved questions
 
 What parts of the design are still to be done?

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This is an excerpt of the [List of RFCs by status](./RFCs-by-status.md) showing 
 
 - [#0009 MPID Messaging System](./text/0009-mpid-messaging/0009-mpid-messaging.md)
 - [#0021 MPID Message Delete](./text/0021-mpid-messaging-delete/0021-mpid-messaging-delete.md)
+- [#0036 safe_launcher API v0.5](./text/0036-launcher-api-v0.5/0036-launcher-api-v0.5.md)
 
 ## When you need to follow this process
 [When you need to follow this process]: #when-you-need-to-follow-this-process

--- a/RFCs-by-status.md
+++ b/RFCs-by-status.md
@@ -6,6 +6,7 @@ A list of all RFCs by their current status.
 
  - [#0009 MPID Messaging System](./text/0009-mpid-messaging/0009-mpid-messaging.md)
  - [#0021 MPID Message Delete](./text/0021-mpid-messaging-delete/0021-mpid-messaging-delete.md)
+ - [#0036 safe_launcher API v0.5](./text/0036-launcher-api-v0.5/0036-launcher-api-v0.5.md)
 
 ## Proposed RFCs
 
@@ -18,7 +19,6 @@ A list of all RFCs by their current status.
  - [#0030 Secure node join](./text/0030-secure-node-join/0030-secure-node-join.md)
  - [#0033 Fake Account Packet](./text/0033-fake-account-packet/0033-fake-account-packet.md)
  - [#0034 Refactor `ImmutableData::name()` Function](./text/0034-immutable-data-name-function/0034-immutable-data-name-function.md)
- - [#0036 safe_launcher API v0.5](./text/0036-launcher-api-v0.5/0036-launcher-api-v0.5.md)
 
 ## Agreed RFCs
 
@@ -52,4 +52,4 @@ A list of all RFCs by their current status.
  - [#0017 Launcher DNS API](./text/0017-launcher-dns-api/0017-launcher-dns-api.md)
 
 
-(Last updated _Tue 31 May 17:03:49 BST 2016_ at REV [897545b](https://github.com/maidsafe/rfcs/commit/897545b9aa1621e13dc475b853a7006ba0552039))
+(Last updated _Tue 14 Jun 11:57:22 BST 2016_ at REV [48fd6af](https://github.com/maidsafe/rfcs/commit/48fd6af74df19a9de6a6d1b048d25d539abf9ec3))

--- a/text/0000-sentinel/0000-sentinel.md
+++ b/text/0000-sentinel/0000-sentinel.md
@@ -7,12 +7,12 @@
 - RFC PR:
 - Issue number:
 
-# Summary
+## Summary
 
 This document tries to explain basic principles behind security
 on the SAFE network.
 
-# Motivation
+## Motivation
 
 Big part of algorihms behind the SAFE network rely on so called local
 group consensus. What it basically means is that for a node to act in some
@@ -29,7 +29,7 @@ adversary to enter an arbitrary group of close nodes. The purpose of the
 Sentinel is then to ensure that the set of these instructing
 nodes really lives in a Group surrounding the given HASH.
 
-# Detailed design
+## Detailed design
 
 Currently we have a need for three kinds of sentinels:
 
@@ -46,7 +46,7 @@ allows us to request fewer network send calls as shall be explained later.
 * __AccountSentinel__: This one validates `Refresh` messages which arrived from
 our `close group` (i.e. a group we're part of).
 
-## PureSentinel
+### PureSentinel
 
 Let's consider a situation where a group G sends us a `Put` message. Since
 this is a group message we expect to receive many copies of it. And since we want
@@ -74,7 +74,7 @@ it turns out that this step is essential because this way it
 is the network that decides who belongs to G (by means of the
 parallel send implemented by routing).
 
-## KeySentinel
+### KeySentinel
 
 This sentinel is intended for use when a node wants to find
 a group of nodes at some location. This normally hapens during
@@ -95,7 +95,7 @@ apart from the NameType and the PublicKey which is then used
 by the Routing library. The rest of the validation procedure
 is analoguous as well.
 
-## AccountSentinel
+### AccountSentinel
 
 This one is simplest of the three. It is because we're only expecting
 messages to go through this sentinel if they arrive from our own
@@ -107,12 +107,12 @@ accumulating messages by a certain key and once a quorum of messages
 with the same key is reached, they are gathered in a list and returned
 for further processing by the Routing library.
 
-# Drawbacks
+## Drawbacks
 
 The Pure and Key sentinels request public keys of group members, this
 crates additional traffic.
 
-# Alternatives
+## Alternatives
 
 Sentinels currently validate nodes by requiring that at least
 a quorum size of other nodes confirm their public key. It is unclear
@@ -125,7 +125,7 @@ if A confirms C and C confirms B then that means A confirms B.
 If we did decide this stronger requirement is essential, the
 algorighm would reduce to finding loops in a graph.
 
-# Unresolved questions
+## Unresolved questions
 
 All three types of sentinels currently live in the `Sentinel` library.
 In order to achieve genericity of such library it avoids using

--- a/text/0001-use-public-key-for-id-on-all-messages/0001-use-public-key-for-id-on-all-messages.md
+++ b/text/0001-use-public-key-for-id-on-all-messages/0001-use-public-key-for-id-on-all-messages.md
@@ -6,7 +6,7 @@
 - Start Date: 23-06-2015
 - Issue number: #22
 
-# Summary
+## Summary
 
 At the moment client Id packets are created and a hash of these packets used as identity. This is stored on the network as a `key` (ie the hash) / `value` (the public key) pair. These packets have to be available prior to the client storing data onto the network.
 
@@ -16,13 +16,13 @@ As such this requires an initial unauthorised `Put` as the client is not known t
 
 This proposal removes all of this indirection and instead allows the client to be recognised by the public key included in messages or data types. Such messages and data types will be signed by the `secret key` that is paired with this public key. As only the owner should have access to this `secret key` then it can be assumed the message or request to mutate data is indeed valid in a cryptographically secure manner.
 
-# Motivation
+## Motivation
 
 Storing Id packets is a strain on the network. Lookups are a strain and will slow down network actions. Id packets themselves may be a security issue (can they be hacked), although highly unlikely, it is impossible to hack if they do not exist!
 
 This mechanism does not reduce the total number of clients or types of clients as they all exist in an address space of 2^256 and app developers can use multiple Id's in very clever ways, such as the SAFE network does not distinguish between public id's and private id's. Now these and more are possible. Id's could be created to share data types (as co-owners) and allow shares access and write capability between applications and groups.
 
-# Detailed design
+## Detailed design
 
 As clients `Put` data or messages on the network (i.e. ask to create) they send such requests via the `ClientManager` type persona (`MaidManager` in the case of data). These requests are signed and include the clients `PublicKey`. This public key can be allocated for, or matched to an existing, client account. The `ClientManager` may then take any action, such as authorising the `Put`, taking a balance etc. and all against the key.
 
@@ -32,14 +32,14 @@ Clients may identify themselves using the public key as their node address by si
 
 Clients themselves no longer will require to store Id's packets on the network (although they can via `StructuredData`). `PublicId` types are no longer required in the maidsafe_types library (maidsafe_client exclusive now).
 
-# Drawbacks
+## Drawbacks
 
 To be identified
 
-# Alternatives
+## Alternatives
 
 Alternatively the status quo could be left in place
 
-# Unresolved questions
+## Unresolved questions
 
 To be resolved during evaluation.

--- a/text/0002-name-service/0002-name-service.md
+++ b/text/0002-name-service/0002-name-service.md
@@ -7,17 +7,17 @@
 - Start Date: 27-06-2015
 - Issue number: #23
 
-# Summary
+## Summary
 
 In the current Internet Domains are referenced via a naming system which comprises an indexing mechanism. This indexing mechanism is centralised and controlled, with the ability for countries and ISPs to switch it off, pollute data with advertising data and much worse. The SAFE network on the other had offers a 'free (as in beer)' mechanism to locate data linked to a name. This proposal outlines a mechanism to look up data related to any name.
 
 This data includes, long name (could be real name is users wish), web site id, blog id, micro-blog id and may be extended to include additional information as the network develops.
 
-# Motivation
+## Motivation
 
 In networks people expect to be able to lookup services related to names. In the SAFE network this includes the ability to retrieve public keys to encrypt data to that id, in cases where privacy is a requirement (e.g. in SAFE all messages are encrypted between identities). The opportunity for people to create and link web sites and other services is also a motivation for implementing such a system.
 
-# Detailed design
+## Detailed design
 
 This is a simple use case for `Unified Structured Data` (see RFC 0000). In this case we require to set three items
 
@@ -44,15 +44,15 @@ This is very likely to extend as the services on the network grows.
 
 To find this information an application will `Hash(Hash(public_name) + type_tag))` and retrieve this packet.
 
-# Drawbacks
+## Drawbacks
 
 None found at this time.
 
-# Alternatives
+## Alternatives
 
 Alternatives could be clients, passing this information via a series of messages, but this requires both parties being online or able to wait for each other to come online.
 
-# Unresolved questions
+## Unresolved questions
 
 1. Should this struct contain the actual public_name (handle) as this may allow some indexing mechanism, which is prevented with this design (on purpose).
 

--- a/text/0003-reserved-names/0003-reserved-names.md
+++ b/text/0003-reserved-names/0003-reserved-names.md
@@ -6,16 +6,16 @@
 - Start Date: 27-06-2015
 - Issue number: #24
 
-# Summary
+## Summary
 
 A very simple RFC to outline and maintain (over time) a known list of `type_tags` for `StructuredData` types.
 
-# Motivation
+## Motivation
 
 As with `IANA` type registries or indeed the common well known service ports found in many Operating Systems (OSs) this list will allow applications that achieve the happy position of being commonplace, or extremely popular to  register their `type_tag` in this file. This allows other application developers to choose a non registered tag to
 reduce any confusion or name collisions (although the latter is extremely improbable, given the address space).
 
-# Detailed design
+## Detailed design
 
 0            --      Login session
 
@@ -39,14 +39,14 @@ reduce any confusion or name collisions (although the latter is extremely improb
 
 The numbers 0-10,000 will be hard coded into vaults for the use of the core network only and will not be likely available to application developers to overwrite their structure.
 
-# Drawbacks
+## Drawbacks
 
 None known
 
-# Alternatives
+## Alternatives
 
 Alternatively this list could not exist and there could be a free for all approach.
 
-# Unresolved questions
+## Unresolved questions
 
 1. The range 0-10,000 is a subjective one and may not be correct.

--- a/text/0004-farm-attempt/0004-farm-attempt.md
+++ b/text/0004-farm-attempt/0004-farm-attempt.md
@@ -6,48 +6,48 @@
 - Start Date: 24-06-2015
 - Issue number: #25
 
-# Summary
+## Summary
 
 This proposal outlines an initial design to test the efficiency and security of farming attempts. This involves making use of the Farming Rate (FR) which is the rate at which farming attempts are made. It is assumed the farming rate will include payments to care development, content producers and most significantly farmers (or providers of the network resource).
 
-# Motivation
+## Motivation
 
 To ensure network stability and resource availability a reward mechanism is required to ensure the use of resource is balanced with the supply of resource.
 
-# Scope of work
+## Scope of work
 
 This implementation will be solely in the vault library. This will include several steps. The client lib will require to be aware of the actual safecoin type (again `StructuredData`).
 
-# Detailed design
+## Detailed design
 
 On receipt of a `Get` request for `ImmutableData` the `DataManager` calculates the SHA512 Hash of the `name` of the `ImmutableData` concatenated with the`PmidNode`. This result is then modulo divided by the farming rate (FR). The rate attempts should divide the award between 4 distinct groups (for clarity, this algorithm is applied to all `PmidNodes` that hold this data element in the current group).
 
-## Rate attempts
+### Rate attempts
 
 1. PmidNodes -> tested at 100% of FR [i.e. Farming rate * 1]
 2. App Developer -> tested at 10% of FR [i.e. Farming rate * 1.1]
 3. Publisher -> tested at 10% of FR [i.e. Farming rate * 1.1]
 4. Core development -> tested at 5% of FR [i.e. Farming rate * 1.05]
 
-## Payment address
+### Payment address
 
 1. PmidNodes -> Registers an Optional (if set by user) wallet address on any store of data to it
 2. App Developer -> App developers will include wallet address in any `Get` request
 3. Publisher -> As data is stored a wallet address of the owner is stored if this is first time seen on the network (stored in DM account for the data element)
 4. Core development -> Initially every node will be aware of a hard coded wallet address for core development. This will likely lead to a multi-sign wallet.
 
-## Farm process
+### Farm process
 
 When the initial farming test above is true (the modulo division `==0` ) then the `DataManager`s `Post` a Farm request message to the group closest to the combined Hash (i.e. `Hash(ImmutableData + PmidHolder)`). This request includes the original hashes + hash of chunk requested + current farming rate of the group as well as wallet address. This is confirmed at the receiving group and they check for the existence of a safecoin space (i.e. there is no safecoin with this name already). If this is successful then a further check is made to confirm there is a `DataManager` group (implicit as routing does this). A safecoin is then created and a message sent to the wallet holder of the request. All these requests must be digitally signed and confirmed at receiving end (implicit in sentnel).
 
-# Drawbacks
+## Drawbacks
 
 Left blank for discussion
 
-# Alternatives
+## Alternatives
 
 Initially there was no safecoin and the network would have been built in a quid pro quo manner. Third involved users requiring a vault to store data and the user then being allocated that amount of data to store. It was rather inflexible and involved a tremendous amount of logic. It was an alternative. It should be noted the very original designs did include a digital currency which would have suited this purpose perfectly as safecoin now will.
 
-# Unresolved questions
+## Unresolved questions
 
 1. Link farming rate to resource cost (what users must pay). This will form a separate RFC.

--- a/text/0005-balance-network-resources/0005-balance-network-resources.md
+++ b/text/0005-balance-network-resources/0005-balance-network-resources.md
@@ -6,17 +6,17 @@
 - Start Date: 25-06-2015
 - Issue number: #26
 
-# Summary
+## Summary
 
 This proposals intent is to provide a balance for Farming Rate verses purchase price of network resources that users are charged. The farming rate (`fr`) is calculated by the network as described in RFC 0004. As the farming rate increases, farmers earn less as more `Get` requests per attempt is required. As the farming rate increases then it follows users pay less (as the network is oversupplied) for resources. The key issue is to identify the link between these two numbers. It is assumed all chunks are 1Mb in this proposition, this is very realistic in terms of calculation and any error favours the user.
 
-# Motivation
+## Motivation
 
 This decentralised autonomous network must encourage resource providers. This is anticipated to be similar to skype, bittorrent etc. in that people will provide resources, simply because they are getting something from the network. This proposal enhances safecoin to provide an additional encouragement. That incentive is the payment of providers of resources to include application development, content availability and importantly resources, in terms of disk space, cpu processing, memory, bandwidth etc. in fact everything required to provide data availability (and compute) to all users, irrespective of the use or users.
 
 Many confuse any out of network price fluctuation would in fact alter the network balancing process, in fact it is unrelated as the balance simply increases reward when space is needed and reduces when space is abundant. There is no relation to the cost of safecoin and network balancing, as long as a safecoin can change hands for a cost then the number of safecoin per unit of fiat is handled by the network.
 
-# Detailed design
+## Detailed design
 
 A very simple approach is to use a fixed approach and measure via testing. It is assumed there will be considerably more reads from the network than stores of data. The cost per MB, electricity, B/W and size of storage are all factors in this algorithm. Therefore testing and sampling of a running network is essential. To begin the simple approach is best.
 
@@ -30,7 +30,7 @@ The `FR` is the local farming rate known to the `ClientManager` and may slightly
 
 It is assumed clients will pay at least one safecoin to create an account. This payment will be converted immediately to Mb of storage space and the client can query this figure at any time.
 
-# Drawbacks
+## Drawbacks
 
 1. This is a very simple approach to a balancing algorithm, it could be argued this could be modeled.
 
@@ -38,10 +38,10 @@ It is assumed clients will pay at least one safecoin to create an account. This 
 
 3. It is very likely the agreed algorithm will evolve over time, which may not be clearly understood by all the community, therefore clear RFC proposals and discussions should certainly take place when such change may happen.
 
-# Alternatives
+## Alternatives
 
 It is expected there may be, in fact, a substantially more accurate initial estimate or an algorithm that is likely to be more capable of aligning with changing Farming Rates.
 
-# Unresolved questions
+## Unresolved questions
 
 Left open to review process to identify

--- a/text/0006-address-relocation/0006-address-relocation.md
+++ b/text/0006-address-relocation/0006-address-relocation.md
@@ -6,15 +6,15 @@
 - Start Date: 21-09-2015
 - RFC PR: #40
 
-# Summary
+## Summary
 
 Prevent any single address being used more than once during address relocation. Prevent a potential attack where a node gains overall/majority influence in a group setting.
 
-# Motivation
+## Motivation
 
 An attack exists for a node to generate public-private key pairs off-line to derived identities close to a specific target. It would then be able to connect close to a desired target. Repeating this would enable an actor to connect a majority of nodes close to the targeted region in address space. For this reason Address Relocation has been designed and implemented.  Address Relocation blocks off-line generation of identities as the network is an active part of irreversibly and deterministically establishing a uniformly distributed location for the node to connect to the network.
 
-# Detailed design
+## Detailed design
 
 A node joining the SAFE network generates a new cryptographic key pair to access the network for each session. The generated public key, K, is then cryptographically hashed using some hash function H to give H(K). The node then sends a message, containing K, to the group H(K) requesting a network identifier for the session. On receipt of such a request each node belonging to the group hashes the concatenation of H(K) with the two closest nodes, N1, N2 ordered, in xor distance from H(K) present in their routing tables, giving H(H(K) + N1 + N2) = N, the identifier the node will use on the network for the session.
 
@@ -22,20 +22,20 @@ Having computed N, each node in the group H(K) sends a message, containing K, to
 
 In its current form the process ensures that a joining node cannot occupy a position of its own choosing. However, in a semi-stable network state it may be possible given the joining node knows the two closest nodes, N3, N4 say, in its joined group to generate keys that are relocated close to some identifier, I say, and thus obtain group influence at that location. It is the purpose of this RFC to avoid that possibility by storing the two close node identities, N3 and N4, at each node belonging to the joined group in order to reject relocations involving either of those nodes if they occur more than once for the participating nodes in a given session.
 
-## Implementation
+### Implementation
 
 The `RoutingNode` function `handle_request_network_name` calculates a relocated name for a node joining the network. The utils.rs function `pub fn calculate_relocated_name(mut close_nodes: Vec<::NameType>, original_name: &::NameType) -> Result<::NameType, ::error::RoutingError>`, takes the close nodes from the routing table and original name, K, as arguments, returning H(K + N1 + N2) = N, in the notation above, and is used for this purpose.
 
 Add a vector of node names used in address relocations to `RoutingCore`. Move the function `calculate_relocated_name` to `RoutingCore` with signature taking K as argument. Rework the code from `calculate_relocated_name` to return a `::error::RoutingError` if any of the names in the added vector will be used during the current name relocation calculation, otherwise add the two new names used in the calculation to the vector and return the calculated name.
 
-# Drawbacks
+## Drawbacks
 
 An analysis of the complexity of producing network identifiers at will under various states of network churn and size could provide a contradictory perspective.
 
-# Alternatives
+## Alternatives
 
 The analysis in the Drawbacks section above provides motivation to render the current process sufficient in terms of network security.
 
-# Unresolved questions
+## Unresolved questions
 
 The intention is to implement the currently proposed design in the absence of evidence contradictory to it's requirement.

--- a/text/0007-launcher-not-as-service/0007-launcher-not-as-a-service.md
+++ b/text/0007-launcher-not-as-service/0007-launcher-not-as-a-service.md
@@ -6,17 +6,17 @@
 - Start Date: 11-September-2015
 - RFC PR: #41
 
-# Summary
+## Summary
 
 Launcher will be a gateway for any app that wants to work on the SAFE Network on a user's behalf. It will generate a single set of ownership and crypto keys which it will give to all the apps that want to access the Network on user's behalf. It will also give access to `SAFEDrive` with an intention to allow apps to share data among themselves.
 
-# Motivation
+## Motivation
 
-## Why?
+### Why?
 
 App's access of the SAFE Network on behalf of the user is an issue with high security concerns. Without Launcher, every app would ask for user credentials to log into the Network. This means that sensitive information like user's session packet etc., are compromised and can be potentially misused. Launcher will prevent this from happening by being the only one that gets the user credential. Apps only communicate with the Network with keys given by Launcher on user's behalf. These will be different to the user's MAID keys.
 
-## What cases does it support?
+### What cases does it support?
 
 Launcher
 
@@ -27,9 +27,9 @@ Launcher
 1. will manage metadata related to apps to give uniformity in experience when shifting from one machine to another - e.g. if app `A` is installed in machine 1 then when the user logs into machine 2 using his/her SAFE Account via Launcher, he/she will be presented with a union of all the apps that were installed on all the machines which access the SAFE Network on his/her behalf.
 
 1. along with [safe_vault](https://github.com/maidsafe/safe_vault) will manage the mapping and de-mapping of ownership keys for an app.
-# Detailed design
+## Detailed design
 
-## User's Login Session Packet (for reference)
+### User's Login Session Packet (for reference)
 This is only to provide a context to the references to it below. This might change in future without affecting this RFC (i.e. only a small portion of this is actually relevant for this RFC).
 ```
 Account {
@@ -45,7 +45,7 @@ Account {
 ```
 - The Root Directories are encrypted with MAID-keys.
 
-## Start Flow
+### Start Flow
 
 **step 0:** Start Launcher.
 
@@ -65,7 +65,7 @@ Account {
 
 **step 8:** Launcher will listen on local host: `127.0.9.9:30000`. If unavailable, it will increment the port till a valid TCP Listener is in place. This will be thus `127.0.9.9:Launcher-Port`. This will remain on till Launcher is closed. We will call this combination `<Laucher-IP:Launcher-Port>`.
 
-## Add App Flow
+### Add App Flow
 
 **step 0:** User drags `XYZ` App binary into the Launcher to add it. Launcher will ask the user if the app should have access to `SAFEDrive`.
 
@@ -158,11 +158,11 @@ struct Response {
 where `DirectoryKey` is defined [here](https://github.com/ustulation/safe_nfs/blob/master/src/metadata/directory_key.rs).
 - Launcher closes the connection and is no longer needed for this session for this app.
 
-## Reads and Mutations by the App
+### Reads and Mutations by the App
 
 - All `GET/PUT/POST/DELETE`s will go directly to the Network. The app will use `<Launcher Keys>` to encrypt and sign data.
 
-## Remove App Flow
+### Remove App Flow
 
 **procedure 0:** Launcher removes the App as follows:
 - Delete from `<LOCAL-CONFIG-FILE>` (on the user's machine) the following:
@@ -178,13 +178,13 @@ where `DirectoryKey` is defined [here](https://github.com/ustulation/safe_nfs/bl
 
 **procedure 1:** While the other procedure would work, there might be occassions when the user wants to immediately remove the app completely (which also translates as revoke App's permission to mutate network on user's behalf). He may not have access to other machines where the App was installed and may be currently running and the previous procedure requires the user to remove it from all machines. Thus there shall be an option in Launcher to remove App completely irrespective of if it is installed and/or running in other machines. In such cases Launcher will reduce `Reference Count` to 0 and proceed as above for the detection of zero reference count.
 
-## Misc
+### Misc
 - If the App is added to Launcher in one machine, the mention of this will go into `<LAUNCHER-CONFIG-FILE>` as stated previously. It will thus be listed on every machine when user logs into his/her account via Launcher on that machine. However when the App is attempted to be activated on a machine via Launcher where it was not previously added to Launcher then he/she will be prompted to associate a binary. Once done, the information as usual will go into the `<LOCAL-CONFIG-FILE>` on that machine and the user won't be prompted the next time.
 - When the App is started via Launcher, it will first check if the `SHA512(App-Binary)` matches any one of the corresponding entries in the vector in `<LAUNCHER-CONFIG-FILE>`. If it does not Launcher will interpret this as a malacious App that has replaced the App-binary on user's machine, and thus will show a dialog to the user for confirmation  of whether to still continue, because there can be genuine reasons for binary not matching like the App was updated etc.
 
-# Alternatives
+## Alternatives
 There is an RFC proposal for a more robust and complicated design of Launcher which aims at solving many more security concerns.
 
-# Drawbacks
+## Drawbacks
 1. Since same keys are used by all apps, an app can easily gain access to another app's root directory and config files.
 1. Since same keys are used by all apps, an app can continue to access the Network even after it's removal from Launcher. Revocation is not easy and is a tedious process of fetching all user data from the Network, and encrypting and signing them with different keys and making these available to all other authenticated apps (in all machines). The vaults too must be informed and asked to un-map the previous keys and map new ones.

--- a/text/0008-udp-hole-punching/0008-udp-hole-punching.md
+++ b/text/0008-udp-hole-punching/0008-udp-hole-punching.md
@@ -7,13 +7,13 @@
 - RFC PR: #46
 - Issue number: Active - #49
 
-# Summary
+## Summary
 
 In this text we describe an implementation of UDP hole punching process
 to allow for P2P connections of nodes behind NATs in a fully decentralised
 network.
 
-# Motivation
+## Motivation
 
 Most users of the Crust library are expected to run the software on home PCs connected
 to the internet through a router. Routers usually implement some kind of a firewall to
@@ -31,14 +31,14 @@ In the following text the reader is expected to know basic NAT types and how the
 The section 'Methods of translation' on [wikipedia](https://en.wikipedia.org/wiki/Network_address_translation)
 gives a nice overview.
 
-# Detailed design
+## Detailed design
 
 The UDP hole punching process described here consists of two steps:
 
 1. Finding an external mapping of a UDP socket
 2. Do the actual hole punching.
 
-## Finding an external mapping of a UDP socket
+### Finding an external mapping of a UDP socket
 
 Suppose, we have two nodes `A` and `B`, where each one is possibly behind a NAT and
 they want to connect to each other.  Routing needs to send `A` an endpoint of `B` and
@@ -76,7 +76,7 @@ Once upper layers receive such event, they can send/route `MappedUdpSocket::publ
 to node `B`. Once `B` does the same, and upper layers receive `B`’s public endpoint, upper
 layers are ready for the actual hole punching.
 
-## Hole punching
+### Hole punching
 
 The act of hole punching shall be initiated by a function with the following signature:
 
@@ -129,7 +129,7 @@ the following structure:
       peer_addr: io::Result<SocketAddr>,
     }
 
-## Using the punched hole
+### Using the punched hole
 
 After a successful hole-punch, it is assumed that the two peers can communicate
 with each other over the unreliable UDP protocol. At this point we'd like to
@@ -138,13 +138,13 @@ use that UDP socket with protocols such as uTP for added reliability.
 Unfortunatelly, the rust-utp library doesn't currently support rendezvous
 connections, so this functionality will need to be added.
 
-# Drawbacks
+## Drawbacks
 
 The alternative approach described in the next section is simpler in that it doesn't require
 two async calls, instead, it uses only one. Other than that, the simpler approach
 is limited in number of NAT types it can successfully punch through.
 
-# Alternatives
+## Alternatives
 
 Another approach would work with the use of multiplexing. That is, if we had a UDP socket
 which is already connected to a remote peer, we could also use it to communicate
@@ -152,9 +152,9 @@ with other peers as the hole has already been punched. Problem with this approac
 that it would only help with `Full-cone NAT` types because it is the only NAT
 type where a hole punched to one peer/host can be reused with another peers/hosts.
 
-# Unresolved questions
+## Unresolved questions
 
-## What asynchronous primitives should be used for this?
+### What asynchronous primitives should be used for this?
 
 Here are the available options:
 
@@ -186,7 +186,7 @@ Here are the available options:
    for complex and hard-to-read patterns to be hidden behind
    other callback taking functions with more descriptive names.
 
-## How to chose `C(X)`?
+### How to chose `C(X)`?
 
 One criterion for `C(X)` is that it should not be on the same local network as `X`.
 For this we could use the `getifaddrs` function, it gives us `SocketAddrs`
@@ -194,7 +194,7 @@ of our network interfaces, plus the netmasks they use. This information should
 be enough to determine whether `C(X)` is in the same subnet as a given
 interface.
 
-## Should `C(X)` be only one node?
+### Should `C(X)` be only one node?
 
 If we allow for `C(X)` to be more than one node, we could get a reponse quicker
 and more reliable. Additionally getting more than one response can reveal
@@ -204,7 +204,7 @@ the information whether we're behind a Symmetric NAT as two different
 On the other hand, if X is behind a Symmetric NAT, then contacting
 multiple `C(X)`s would disable port prediction.
 
-# Implementation details
+## Implementation details
 
 ```rust
 /// Generate a new number each time this function is called, the new
@@ -360,9 +360,9 @@ pub fn Service::udp_punch_hole(&self,
 
 ```
 
-# Room for improvements
+## Room for improvements
 
-## More robustness on devices with multiple network interfaces
+### More robustness on devices with multiple network interfaces
 
 When `X` connects to `C(X)`, the handshake exchanged contains `U(C(X))`. The
 handshake represents `U(C(X))` like the following:

--- a/text/0012-safecoin-implementation/0012-safecoin-implementation.md
+++ b/text/0012-safecoin-implementation/0012-safecoin-implementation.md
@@ -10,14 +10,14 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 Full implementation of safecoin v1.0. This RFC brings together the following RFCs
 [Farm Attempt](https://github.com/maidsafe/rfcs/blob/master/agreed/0004-Farm-attempt/0004-Farm-attempt.md)
 [Balance Resources](https://github.com/maidsafe/rfcs/blob/master/agreed/0005-balance_network_resources/0005-balance_network_resources.md)
 In addition this RFC will attempt to calculate the existing magic numbers used in previous implementations.
 
-# Motivation
+## Motivation
 
 Safecoin is a valuable part of the SAFE network and allows resource providers to be paid by users of
 that resource. Users in this case are content producers, or those who upload data to the network.
@@ -31,13 +31,13 @@ consumption of resources.
 This RFC will cover farming and payments as well as define the wallet interface for application
 developers.
 
-# Detailed design
+## Detailed design
 
 Initially the cost of resources in some unit must be identified. There are options to measure these
 units in disk space, CPU, bandwidth and more. It is much simpler to define these units as a safecoin,
 which at this time is simply a name given to this overall unit of measure (as far as this RFC is concerned).
 
-## Data/chunk size consideration
+### Data/chunk size consideration
 
 Data of varying sizes is uploaded to the SAFE network. Immutable data can be up to 1Mb and StructuredData
 can be up to 100Kb. To simplify the algorithm and also avoid bad players attempting to swamp the
@@ -50,7 +50,7 @@ In this design each upload (PUT) will incur the same cost, i.e. 1 unit.
 To facilitate this design we will create an internal name to measure this unit of store. This will
 be referred to as a StoreCost in this document.
 
-## Establishing farming rate
+### Establishing farming rate
 
 This section will introduce the following variables:
 
@@ -104,7 +104,7 @@ Since the farming rate decreases as the network grows, it will push the design o
 to ensure the number of chunks active in the network is not excessive.  Archive nodes will be a
 further RFC and should allow farming rates to have a natural minimum.
 
-## Establishing StoreCost
+### Establishing StoreCost
 
 This is an upgrade to RFC [0005](https://github.com/dirvine/rfcs/blob/safecoin_implementation/agreed/0005-balance_network_resources.md) the initial StoreCost
 
@@ -124,7 +124,7 @@ The calculation therefore becomes a simple one (for version 1.0)
 Therefore a safecoin will purchase an amount of storage equivalent to the amount of data stored (and
 active) and the current number of vaults and users on the network.
 
-## Farm request calculation
+### Farm request calculation
 
 The farming request calculation is also a simple affair, but must mitigate against specific attacks
 on the network. These include, but are not limited to:
@@ -150,7 +150,7 @@ This process is outlined as:
      - The safecoin close group then send a receipt message to the wallet address to inform the user
        of a new minted safecoin allocated to them.
 
-## Safecoin Management
+### Safecoin Management
 
 Each safecoin is represented as a piece of data held by the group closest to it's ID. Safecoin data structure is defined as:
 '''rust
@@ -166,7 +166,7 @@ When being asked to transfer the owevership, the request transcript must provide
 
 When being asked to burn a coin, the request must be signed by the current owner and forwarded through that owner's Client Manager group (which will increase allowed storage space at the same time). The piece of safecoin data will then be removed.
 
-## Account Management
+### Account Management
 
 An Account Management group is a group of nodes closest to a user's wallet address. It is resposible for that user's safecoin relation activities: rewarding, transfering or discarding.
 A user's safecoin account is defined as :
@@ -180,16 +180,16 @@ COINS: Vec<SAFECOIN_ID>
 3. transfer in : when being notified by the sender's account group and the safecoin management group, the correspondent safecoin's ID will be inserted into the record.
 4. discarding : This is a special case that no receiver has been specified. the safecoin will be removed from the account and the chosen safecoins' management groups will be notified with a burning request.
 
-## Bootstrap with clients
+### Bootstrap with clients
 
 Although there has been hostility from the community with regard to "something for nothing" approach, there is a necessity for a bootstrap mechanism. As no safecoin can be farmed until data is uploaded there is a cyclic dependency that requires a resolution. To overcome this limitation this RFC will propose that a user account is composed of two parts: safecoin_account and storage_account, every new account created is initialised with safecoin_account holding 0 coins but storage_account holding 50 safecoin equivalent storage allowance. This may be temporary and only used in test-safecoin, but it is likely essential to allow this for the time being. It may be a mechanism to kickstart the network as well.
 
 
-# Drawbacks
+## Drawbacks
 
 These will be added during the review process and will include any concerns form the community forum.
 
-# Alternatives
+## Alternatives
 
 Initially there was no safecoin and the network would have been built in a quid pro quo manner.
 This involved users requiring a vault to store data and the user then being allocated that
@@ -199,7 +199,7 @@ currency which would have suited this purpose perfectly as safecoin now will.
 
 There is an alternative approach outlined [here](https://forum.safenetwork.io/t/safecoin-divisibility/4806/68) which introduces an alternative coin for artists and app developers. This RFC does not limit this proposal and leaves the way open for such an implementation.
 
-# Unresolved questions
+## Unresolved questions
 
 The application developer rewards are seen as a good start to pay creators of applications on the
 app popularity, measured via its use. This design incorrectly identifies the measure of use as the
@@ -207,9 +207,9 @@ number of GET requests the app carries out. A better solution should be found fo
 
 Some have identified an app may
 
-# Implementation overview
+## Implementation overview
 
-## Farming rate method
+### Farming rate method
 
 ```rust
 fn farming_divisor() -> u64 {
@@ -221,7 +221,7 @@ fn farming_divisor() -> u64 {
 }
 ```
 
-## Client Put (StoreCost)
+### Client Put (StoreCost)
 
 ```rust
 fn store_cost() -> u64 {
@@ -272,7 +272,7 @@ if key.is_in_range() { // we are client manager
 }
 ```
 
-## Client account creation, addition
+### Client account creation, addition
 
 ```rust
 fn new_account(name) {
@@ -284,7 +284,7 @@ fn new_account(name) {
 }
 ```
 
-## Safecoin Manager
+### Safecoin Manager
 ```rust
 if coin.is_in_range() { // we are the manager of that coin
     match operation {

--- a/text/0014-unregistered-client-support-in-launcher/0014-unregistered-client-support-in-launcher.md
+++ b/text/0014-unregistered-client-support-in-launcher/0014-unregistered-client-support-in-launcher.md
@@ -7,21 +7,21 @@
 - RFC PR: #66
 - Issue number: Proposed - #67
 
-# Summary
+## Summary
 
 Launcher will need to cater to the requests made by unregistered clients to access the SAFE Network. This RFC details why this is required and how this will be done.
 
-# Conventions
+## Conventions
 - The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
 - `{P}` refers to the payload. More details in the (RFC here](https://github.com/maidsafe/rfcs/blob/master/active/0010-Launcher-as-a-service/Launcher-Service-Documentation.md).
 
-# Motivation
+## Motivation
 
-## Why?
+### Why?
 
 There are plenty of use cases for unregistered clients (those that don't have a valid SAFE Account with `MaidManagers`) to access the SAFE Network. One such example is the browser category. The browsers do not need to create an account to access the SAFE Network nor do they require a registered client engine (one that performs operations on a valid account) because all they care about is the fetching and display of data. This is in line with our philosophy that anyone can fetch data from the SAFE Network - it will be of no use if it is encrypted and client fetching it does not have the decryption keys, but that is another matter. Without Launcher, each such application will have to interface with low level libraries like [safe_core](https://github.com/maidsafe/safe_core) and/or [safe_nfs](https://github.com/maidsafe/safe_nfs). Further every instance of an engine from [safe_core](https://github.com/maidsafe/safe_core) will create a new routing object. All this is unnecessary overhead. Launcher will funnel requests from all unregistered applications through a single instance of an unregistered client engine obtained from [safe_core](https://github.com/maidsafe/safe_core).
 
-# Detailed design
+## Detailed design
 
 There shall be a discovery mechanism in place to detect a Launcher binary running on a machine. For this Launcher shall broadcast a special packet containing a UTF-8 encoded string which will be `--launcher:tcp:<ip>:<port>`. The broadcast shall be done every **5 seconds** on port **59999**. Any application can then connect to Launcher on the announced endpoint. Once the connection is made, it will give Launcher the a special endpoint string that is metioned below. Launcher on receiving this string shall not do further Handshake. It will listen to JSON requests and carry out the tasks as usual, returning either data or error via JSON. The communication will be in plain text instead of cipher text, i.e. these JSONs will be unencrypted. On first such encounter of such a request, Launcher shall request an unregistered client engine from [safe_core](https://github.com/maidsafe/safe_core) and use that for the present as well as for all such future connections. The JSONs are described below.
 
@@ -32,7 +32,7 @@ Handshake for anonymous access:
 }
 ```
 
-## dns
+### dns
 - Addtional requests to those mentioned [here for dns](https://github.com/maidsafe/rfcs/blob/master/active/0010-Launcher-as-a-service/Launcher-Service-Documentation.md)
 ```
 "get-services"
@@ -138,7 +138,7 @@ Associated response
 }
 ```
 
-# Alternative
+## Alternative
 
 1. Another way would be to add applications like browsers like any other app to Launcher and start them via Launcher. During adding of an app, Launcher would additionally prompt the user to specify if this app should be given the previlege to access the Network on his/her behalf or just access the Network anonymously (which will ofcourse limit the permitted operations to only reads). This would have an advantage of not complicating the design by adding UDP discovery mechanism and while also providing a uniform and a consistent interface to the user.
 
@@ -146,7 +146,7 @@ Associated response
 
 3. Third alternative is to just assign a fix TCP endpoint to Launcher process. If Launcher is unable to attach an acceptor to this endpoint it will not start. So we have no discovery process. All apps know where to find Launcher.
 
-# Implementation hints
+## Implementation hints
 
 - [authenticate_app.rs](https://github.com/maidsafe/safe_launcher/blob/master/src/launcher/ipc_server/ipc_session/authenticate_app.rs) will need to be changed to handle mulitple forms of handshake. If the endpoint is anonymous-access, it will not go through the process of handshake any further and just inform `IpcSession` that the handshake is over.
 - [AppAuthenticationEvent](https://github.com/maidsafe/safe_launcher/blob/master/src/launcher/ipc_server/ipc_session/events.rs) will have to be changed to:

--- a/text/0015-vault-config-file/0015-vault-config-file.md
+++ b/text/0015-vault-config-file/0015-vault-config-file.md
@@ -10,13 +10,13 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 This RFC outlines the config file that being required by the vault to initialise personas.
 
-# Motivation
+## Motivation
 
-## Rationale
+### Rationale
 
 During the disscussion [safecoin implementation](https://github.com/maidsafe/rfcs/issues/61) of [RFC SafeCoin Implementation](https://github.com/maidsafe/rfcs/blob/master/proposed/0012-safecoin-implementation/0012-safecoin-implementation.md), it is being assumed that a pmid_node persona needs to be aware of it's owner's wallet address.
 
@@ -24,7 +24,7 @@ In addition to this, when chunk_store being intialized (currently being used by 
 
 To resolved the above issues, a separate config file for vault is proposed to allow user configurable parameters can be loaded and keeps retained across session (restarting of vault).
 
-## Supported Use-Cases
+### Supported Use-Cases
 
 1. User can specify the storage space for pmid_node and sd_manager
 
@@ -35,13 +35,13 @@ To resolved the above issues, a separate config file for vault is proposed to al
 1. In case of the re-installation of Vault executable, the config file shall not be changed.
 
 
-## Expected Outcome
+### Expected Outcome
 
 A separated config file co-existing with the vault exectuable. This will only be accessed during the intialization procedure. Vault executable no longer using any fixed assumed value for chunk_store initialization.
 
-# Detailed design
+## Detailed design
 
-## Overview
+### Overview
 
 The config file shall contains following items:
 	1. wallet_address : the associated address that shall get rewarded for the service provided, in a format of hex code
@@ -63,10 +63,10 @@ Following rules shall also be applied:
 
     2. A default vault of 1000MB for the max storage space will be used if it is not set.
 
-## Implementation Details
+### Implementation Details
 
 
-## Planned Work
+### Planned Work
 
 1. Vault
     1. Config file handler
@@ -79,23 +79,23 @@ Following rules shall also be applied:
 
 
 
-# Drawbacks
+## Drawbacks
 
 None identified, other than increased complexity of Vault and Launcher.
 
-# Alternatives
+## Alternatives
 
 1. It is possible to use command line interaction or passing the listed configurations as program parameters. However, this may cause some issue to the user experience, especially when vault executable needs to be restarted.
 
 1. Regarding the max_space, it is also being proposed by David that a percentage of free space shall be used as a measurement. The recent update in rust file system may enable such calculation to be supported across platforms. Considering there might be multiple vaults running on same machine, a constant check of free space during each store might be necessary.
 
 
-# Unresolved Questions
+## Unresolved Questions
 
 
 
-# Future Work
+## Future Work
 
 
 
-# Appendix
+## Appendix

--- a/text/0017-launcher-dns-api/0017-launcher-dns-api.md
+++ b/text/0017-launcher-dns-api/0017-launcher-dns-api.md
@@ -7,11 +7,11 @@
 - RFC PR: #76
 - Issue number: Proposed - #78
 
-# Summary
+## Summary
 
 Expose needed APIs from safe_launcher to perform public name and service lookup
 
-# Motivation
+## Motivation
 
 At present the launcher exposes API for Registering public names and adding service for a public name.
 To intercept the scheme and serve the content from the browser add-on, the dns_api for
@@ -21,18 +21,18 @@ would allow variety of applications to be built on the network.
 For example, SAFENetwork Service management application could be something which can help users to manage the
 services exposed under their public name.
 
-# Detailed design
+## Detailed design
 
 The APIs are just an extension from the already existing [dns API](https://github.com/maidsafe/safe_launcher/blob/master/src/launcher/parser/dns/mod.rs) exposed from the safe_launcher.
 
-### Get Service Home Directory
+#### Get Service Home Directory
 
-#### Implementation
+##### Implementation
 The request would make use of the [get_home_service_directory](https://github.com/maidsafe/safe_dns/blob/master/src/dns_operations/mod.rs#L150)
 function from safe_dns crate and get the DirectoryKey. Using the directory key the actual directory content is retrieved using the safe_nfs crate.
 The fetched directory is returned as part of the response.
 
-#### Request
+##### Request
 ```javascript
 {
   endpoint: 'safe-api/v1.0/dns/get-service-directory',
@@ -43,9 +43,9 @@ The fetched directory is returned as part of the response.
 }
 ```
 
-#### Response
+##### Response
 
-##### On Success
+###### On Success
 ```javascript
 {
   'id': String, // Base64 String - [ uint8 ... ] SHA512(Request)
@@ -91,7 +91,7 @@ The fetched directory is returned as part of the response.
 }
 ```
 
-##### On Error
+###### On Error
 
 ```javascript
 {
@@ -103,18 +103,18 @@ The fetched directory is returned as part of the response.
 }
 ```
 
-### Get Content from URL Path
+#### Get Content from URL Path
 
 This API would be able to fetch the contents of the file corresponding to the path specified.
 
-#### Implementation
+##### Implementation
 
 Using the `safe_dns` crate the the Service home DirectoryKey can be fetched, and using the
 DirectoryKey the actual Directory can be fetched from the network. Once the directory is
 fetched the file corresponding to the path can be traversed. Error is returned, if the file is not found at the path specified.
 Else the file is retrieved and sent back as response.
 
-#### Request
+##### Request
 ```javascript
 {
   endpoint: 'safe-api/v1.0/dns/get-file-from-service-directory',
@@ -130,9 +130,9 @@ Else the file is retrieved and sent back as response.
 }
 ```
 
-#### Response
+##### Response
 
-##### On Success
+###### On Success
 ```javascript
 {
   id: String
@@ -152,7 +152,7 @@ Else the file is retrieved and sent back as response.
 }
 ```
 
-##### On Error
+###### On Error
 
 ```javascript
 {
@@ -164,14 +164,14 @@ Else the file is retrieved and sent back as response.
 }
 ```
 
-### List Public Names
+#### List Public Names
 
 API would list all the public name associated to the User Account.
 
-#### Implementation
+##### Implementation
 This is simple a direct API call to the [get_all_registered_names](https://github.com/maidsafe/safe_dns/blob/master/src/dns_operations/mod.rs#L119) function
 
-#### Request
+##### Request
 ```javascript
 {
   endpoint: 'safe-api/v1.0/dns/list-public-names',
@@ -179,9 +179,9 @@ This is simple a direct API call to the [get_all_registered_names](https://githu
 }
 ```
 
-#### Response
+##### Response
 
-##### on Success
+###### on Success
 ```javascript
 {
   id: String,
@@ -191,7 +191,7 @@ This is simple a direct API call to the [get_all_registered_names](https://githu
 }
 ```
 
-##### On Error
+###### On Error
 
 ```javascript
 {
@@ -203,14 +203,14 @@ This is simple a direct API call to the [get_all_registered_names](https://githu
 }
 ```
 
-### List all registered Services for a Public Name
+#### List all registered Services for a Public Name
 
 API would list all the registered services for a public name associated to the User Account
 
-#### Implementation
+##### Implementation
 This is a direct API call to the [get_all_services](https://github.com/maidsafe/safe_dns/blob/master/src/dns_operations/mod.rs#L132) function
 
-#### Request
+##### Request
 ```javascript
 {
   endpoint: 'safe-api/v1.0/dns/list-services',
@@ -220,9 +220,9 @@ This is a direct API call to the [get_all_services](https://github.com/maidsafe/
 }
 ```
 
-#### Response
+##### Response
 
-##### on Success
+###### on Success
 ```javascript
 {
   id: String,
@@ -232,7 +232,7 @@ This is a direct API call to the [get_all_services](https://github.com/maidsafe/
 }
 ```
 
-##### On Error
+###### On Error
 
 ```javascript
 {
@@ -244,14 +244,14 @@ This is a direct API call to the [get_all_services](https://github.com/maidsafe/
 }
 ```
 
-### Delete a Public Name
+#### Delete a Public Name
 
 API would delete a public name associated to the User Account
 
-#### Implementation
+##### Implementation
 This is a direct API call to the [delete_dns](https://github.com/maidsafe/safe_dns/blob/master/src/dns_operations/mod.rs#L95) function
 
-#### Request
+##### Request
 ```javascript
 {
   endpoint: 'safe-api/v1.0/dns/delete-public-name',
@@ -261,9 +261,9 @@ This is a direct API call to the [delete_dns](https://github.com/maidsafe/safe_d
 }
 ```
 
-#### Response
+##### Response
 
-##### on Success
+###### on Success
 ```javascript
 {
   id: String,
@@ -271,7 +271,7 @@ This is a direct API call to the [delete_dns](https://github.com/maidsafe/safe_d
 }
 ```
 
-##### On Error
+###### On Error
 
 ```javascript
 {
@@ -283,13 +283,13 @@ This is a direct API call to the [delete_dns](https://github.com/maidsafe/safe_d
 }
 ```
 
-### Delete a Service for a Public Name
+#### Delete a Service for a Public Name
 API would delete a service for a public name associated to the User Account.
 
-#### Implementation
+##### Implementation
 This is a direct API call to the [remove_service](https://github.com/maidsafe/safe_dns/blob/master/src/dns_operations/mod.rs#L180) function
 
-#### Request
+##### Request
 ```javascript
 {
   endpoint: 'safe-api/v1.0/dns/delete-service',
@@ -300,9 +300,9 @@ This is a direct API call to the [remove_service](https://github.com/maidsafe/sa
 }
 ```
 
-#### Response
+##### Response
 
-##### on Success
+###### on Success
 ```javascript
 {
   id: String,
@@ -310,7 +310,7 @@ This is a direct API call to the [remove_service](https://github.com/maidsafe/sa
 }
 ```
 
-##### On Error
+###### On Error
 
 ```javascript
 {
@@ -322,14 +322,14 @@ This is a direct API call to the [remove_service](https://github.com/maidsafe/sa
 }
 ```
 
-# Drawbacks
+## Drawbacks
 
 None
 
-# Alternatives
+## Alternatives
 
 None
 
-# Unresolved questions
+## Unresolved questions
 
 None

--- a/text/0019-new-kademlia-routing-logic/0019-new-kademlia-routing-logic.md
+++ b/text/0019-new-kademlia-routing-logic/0019-new-kademlia-routing-logic.md
@@ -8,7 +8,7 @@
 - Issue number:
 
 
-# Summary
+## Summary
 
 The current mechanism implemented in the [kademlia_routing_table][1] and [routing][2] crates has several weaknesses that lead to potential problems affecting security, performance and even basic functionality.
 
@@ -16,7 +16,7 @@ The current mechanism implemented in the [kademlia_routing_table][1] and [routin
 [2]: https://github.com/maidsafe/routing
 
 
-# Motivation
+## Motivation
 
 In the current implementation,
 
@@ -35,7 +35,7 @@ Of course a peer-to-peer network has to deal with lots of unpredictable problems
 Instead of detailing how and where the above points fail, this is a proposal to make some changes to the routing logic, together with a rigorous argument why this will make the following guarantees in common scenarios:
 
 
-## Guaranteed properties
+### Guaranteed properties
 
 1. The number of nodes in the network with `node.is_close(target) == true` is exactly `GROUP_SIZE` for each target address.
 2. Each node in a given address' close group is connected to each other node in that group. In particular, every node is connected to its own close group.
@@ -47,19 +47,19 @@ Instead of detailing how and where the above points fail, this is a proposal to 
 other, ... etc.
 
 
-# Detailed design
+## Detailed design
 
 The network will attempt to always satisfy the following invariant:
 
 
-## The invariant
+### The invariant
 
 In every node, every bucket is maximally filled, and every node knows its close group. That means:
 
 Whenever a bucket has less than `BUCKET_SIZE` entries, it contains *all nodes in the network* that have the corresponding bucket distance.
 
 
-## Changes to the routing logic
+### Changes to the routing logic
 
 In `kademlia_routing_table`:
 
@@ -81,7 +81,7 @@ In routing:
 See the appendix below for proofs that the invariant and these changes will guarantee the desired properties.
 
 
-## Node insertion
+### Node insertion
 
 After adding its close group to the routing table, a new node knows that only the buckets up to the first one that currently has an entry can potentially have entries. (Nodes in later buckets would belong to the close group!) For each such
 bucket `i` that is not full (i. e. has `GROUP_SIZE` entries) yet, the node sends a `GetCloseGroup` request to the `NaeManager` of its `i`-th bucket address.
@@ -96,7 +96,7 @@ So whenever a node `n` adds a new node to a bucket `i` that was not full, `n` ne
 this will reach every node with `bi(m, n) > i`. (In a balanced network with an even distribution of addresses, this should rarely be substantially more than `GROUP_SIZE` nodes.)
 
 
-## Node removal
+### Node removal
 
 Since we keep connections open to each routing table entry, every contact of a leaving node learns about the removal. (Should we change that, a periodic check needs to be introduced.)
 
@@ -105,7 +105,7 @@ If a node loses a connection in a bucket that is not full, no action needs to be
 If the bucket was full before, the entry probably needs to be replaced. To do that, the node sends another `GetPublicIdWithEndpoints` request to the bucket address of the modified bucket, as if it had just joined, to obtain the contact information of the *new* close group of its `i`-th bucket and refill it.
 
 
-## Churn
+### Churn
 
 If a node is joining or leaving, the upper layers are informed about it so that they can adapt to the change in the network, e. g. restore the desired replication number of data chunks. The nodes that need to act on this are those which are in any close group together with the new/lost node.
 
@@ -117,12 +117,12 @@ If the bucket `i` is full, then we are not close to any address that disagrees w
 So a `Churn` event needs to be raised if `n` is in a non-full bucket or we have less than `GROUP_SIZE - 1` contacts with a bucket index greater than `n`'s.
 
 
-# Drawbacks
+## Drawbacks
 
 The expected routing table size for a network with `2ⁿ` nodes will be about `GROUP_SIZE * n`. Each of these entries currently corresponds to at least one open connection and two threads. It would therefore be desirable to reduce the routing table size.
 
 
-# Unresolved questions
+## Unresolved questions
 
 The idea behind group authorities (close groups) as well as parallelism (sending the message along more than one path) is to provide security and redundancy. However, the former measure can easily bypassed if the latter is undermined: A single node could invent a whole close group and claim that it is relaying messages from them. The recipient usually doesn't know the sender: They neither know their public keys, nor do they know the network layout around the sender, so they don't know whether the sender actually *is* close to the source address, nor whether the sender is a legitimate node at all.
 
@@ -141,7 +141,7 @@ Maybe there are ways to change the routing algorithm so that the paths of the co
 * Nodes could have one of `GROUP_SIZE` colours. A close group consists of one node in each colour: the single closest node to the target with that colour. Every message copy is routed via a path that stays exclusively in one colour, until it reaches the destination, making it *impossible* for the copies to collide. This would change the routing algorithm considerably: Instead of one table with bucket size `GROUP_SIZE`, each node would have to keep `GROUP_SIZE` tables - one for each colour - with bucket size 1.
 
 
-# Alternatives
+## Alternatives
 
 If the routing table size turns out to be too large in practice, we could let connections time out: Entries we haven't communicated with within some period of time are disconnected, without being removed from the routing table. The
 connection is reestablished periodically to check whether the node is still there, as well as whenever we need to route messages via them. This should allow us to keep only `PARALLELISM` connections open per bucket most of the time.
@@ -151,7 +151,7 @@ We could also experiment with smaller values for `GROUP_SIZE` and `PARALLELISM`,
 Finally, if it turns out to be a problem that we never drop nodes (it shouldn't, because we are only allowed to add nodes that are close to one of our bucket addresses anyway), nodes could periodically send `IDontWantToTalkToYouAnymore` messages to every entry in an overflowing bucket except the `BUCKET_SIZE` closest ones to the bucket address. The other node then drops the connection if it also doesn't need it anymore.
 
 
-# Appendix: Proofs
+## Appendix: Proofs
 
 We prove that whenever the invariant holds, the desired properties are guaranteed.
 

--- a/text/0020-crust-refactor/0020-crust-refactor.md
+++ b/text/0020-crust-refactor/0020-crust-refactor.md
@@ -8,12 +8,12 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 The current design of crust is inefficient and cumbersome to use. This RFC
 proposes a restructure of crust and it's API.
 
-# Motivation
+## Motivation
 
 * Efficiency
 
@@ -83,9 +83,9 @@ monitor and filter it's own events.
     This makes it easy to write code where a thread can block forever and never
     get cleaned up.
 
-# Detailed design
+## Detailed design
 
-## Design goals
+### Design goals
 
 Everything considered, what sort of design goals should crust strive for? In my view, some
 sensible goals are to be:
@@ -141,7 +141,7 @@ sensible goals are to be:
   `Service` the user should be able to statically guarantee that all resources
   associated with the service have been cleaned up.
 
-## Components
+### Components
 
 The unix philosophy is that programs (or libraries as it may be) should do one
 thing and do it well but crust currently performs several distinct tasks. Some
@@ -162,7 +162,7 @@ proposed APIs of these libraries are introduced in four separate documents
 * [transport](transport-library.md)
 * [crust](crust-library.md)
 
-## Libraries
+### Libraries
 
 This RFC proposes that we make of use of [mioco](https://github.com/dpc/mioco)
 as the basis of the transport library. Mioco will allow us to write code that
@@ -179,14 +179,14 @@ recommends the use of scoped threads from the crossbeam library. These will
 allow us to statically guarantee that threads are not leaked and allows threads
 to share borrowed data with the their child threads.
 
-# Drawbacks
+## Drawbacks
 
 Needs to be implemented.
 
-# Alternatives
+## Alternatives
 
 Not do this
 
-# Unresolved Questions
+## Unresolved Questions
 
 None.

--- a/text/0021-mpid-messaging-delete/0021-mpid-messaging-delete.md
+++ b/text/0021-mpid-messaging-delete/0021-mpid-messaging-delete.md
@@ -8,15 +8,15 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 The `MpidMessageWrapper` enum used as the serialised `PlainData::value` for MPID-messaging `Put/Post` requests/responses should for the sake of consistency as well as efficiency include `Delete` requests. Currently `Put/Post` requests/responses are passed to the `MpidManager` to handle, whereas, `Delete` requests for messages in a `Client`'s `Outbox` or headers in the `Inbox` are not catered for. Adding `DeleteMessage` and `DeleteHeader` to `MpidMessageWrapper` will allow those messages to be passed to the `MpidManager` in order to be handled properly based on information only available to the `MpidManager` with respect to messaging.  
 
-# Motivation
+## Motivation
 
 The MPID-Messaging mechanism as it stands uses the `PlainData` type to issue requests and responses between peers. On receipt of any message a vault parses the outer message before passing it to the relevant persona. Currently `Put` and `Post` for a `PlainData` type are passed to the `MpidManager` to process by further parsing the `PlainData::value` and acting in accordance with resultant type. It is proposed to add to the `MpidMessageWrapper` values that can be parsed by the `MpidManager` on receipt of `Delete` requests arriving as `PlainData`.
 
-# Detailed design
+## Detailed design
 
 The current `MpidMessageWrapper` is given as,
 
@@ -65,14 +65,14 @@ pub fn handle_delete(&mut self, routing_node: &RoutingNode, request: &RequestMes
 }
 ```
 
-# Drawbacks
+## Drawbacks
 
 Since no `Authority` is defined for `MpidManager`'s, `PlainData` messages used for Mpid-Messaging arrive at a vault from `Client` to `ClientManager` preventing the use of `PlainData` in other scenarios.
 
-# Alternatives
+## Alternatives
 
 Add an `Mpidmanager` authority to separate the responsibilty of handling individual data types on a per persona basis. Mostly related to the drawback observed above, and will nevertheless require some form of deletion capability to be included, anticipated to be that suggested by the current proposal.
 
-# Unresolved questions
+## Unresolved questions
 
 N/A

--- a/text/0022-messaging-example-in-safe_core/0022-messaging-example-in-safe_core.md
+++ b/text/0022-messaging-example-in-safe_core/0022-messaging-example-in-safe_core.md
@@ -8,15 +8,15 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 Expand the current example in `safe_core` to include the features of creating an mpid_account for messaging and send/receive a message to/from a peer user.
 
-# Motivation
+## Motivation
 
 The current `safe_core` has an example `safe_client` showing how a user can create an account and login to the Vault network. With the messaging feature now having been implemented on the Vault and Client side, we wish to expand the `safe_core` example to include this messaging feature. This can shall showcase how secured messaging works within the distributed Vault network, and also to testify the current implementation from both Vault and the Client side.
 
-# Detailed design
+## Detailed design
 
 The account creation and login part within the current `safe_client` will remain unchanged.
 
@@ -67,7 +67,7 @@ loop {
 ```
 
 
-# Drawbacks
+## Drawbacks
 
 1, To avoid exchanging long hex code mpid_account, the example code needs to carry out a hash function, so that it is a human readable memorable word that can be used as an mpid_account name.
 
@@ -75,10 +75,10 @@ loop {
 
 3, The secret key from maid_account has been used as the signing secret key for the mpid messaging.
 
-# Alternatives
+## Alternatives
 
 N/A
 
-# Unresolved questions
+## Unresolved questions
 
 N/A

--- a/text/0023-immutable-data-type-naming/0023-immutable-data-type-naming.md
+++ b/text/0023-immutable-data-type-naming/0023-immutable-data-type-naming.md
@@ -8,23 +8,23 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 For security and integrity of data, the design of the SAFE network requires that every chunk of `ImmutableData` be stored at three separate locations.  These locations are derived deterministically from the name of the chunk.  The current implementation uses repeated hashing of the chunk's name to derive the secondary names, which could result in all three locations overlapping.  This RFC proposes a solution to resolve this issue, which also has secondary benefits.
 
-# Motivation
+## Motivation
 
 As discussed in the summary, an `ImmutableData` chunk is stored in three locations on the network.  We manipulate the name of the chunk to derive the locations for the copies.  The "Normal" name is the SHA512 hash digest of the contents of the chunk, and this is the primary location.  The secondary locations are defined by the "Backup" name which is the SHA512 digest of the Normal name and by the "Sacrificial" name which is the SHA512 digest of the Backup name.
 
 By using hashing to derive the Backup and Sacrificial names, there is a chance that two or all of the locations will overlap.  In other words, a Vault could end up managing and storing the Normal, Backup and Sacrificial copies of a single chunk.  In an ideal scenario, these locations would have no common Vaults, i.e. no Vault would be responsible for more than one copy of a given chunk.
 
-## Proposed Solution
+### Proposed Solution
 
 The proposed solution involves generating the Backup and Sacrificial names by XORing the Normal name with known values.  As the "distance" between two addresses on the SAFE network is calculated by XORing them, and since XOR is a commutative operation, the values chosen to XOR the Normal name with will effectively be the distances from the Normal name to the secondary names.
 
 Since we want the distances between the groups to maximal, we can take the "maximum address" (where this is (2^512) - 1 (i.e. `111..111`)) divided by two as the target distance between groups.  This means we can define the distance between Normal and Backup as 2^511 (i.e. `100..000`) and between Backup and Sacrificial as (2^511) - 1 (i.e. `011..111`).
 
-## Secondary Benefits
+### Secondary Benefits
 
 The proposed solution has a useful side-effect: for a given name type, both of the other names can be deduced.  This cannot be done for hashing; given a name derived from a hash digest, we cannot calculate the original name, i.e. the hash cannot be reversed.
 
@@ -32,7 +32,7 @@ This is useful since a Vault which is managing a Backup or Sacrificial copy of a
 
 A further benefit is that XOR is a faster operation than SHA512 hash; in benchmarks, using the proposed solution was between 15% and 20% faster than using the existing implementation.
 
-# Detailed Design
+## Detailed Design
 
 The proposed change would define the following constants and function:
 
@@ -103,15 +103,15 @@ pub fn sacrificial_to_backup(name: &XorName) -> XorName {
 
 A sample implementation including the benchmark tests is available [here](https://gitlab.com/Fraser999/RFC-0023-ImmutableData-Type-Naming).
 
-# Drawbacks
+## Drawbacks
 
 None.
 
-# Alternatives
+## Alternatives
 
 * Rather than XORing full IDs, simply XOR the first (most significant) byte.
 * Continue to use the existing implementation.
 
-# Unresolved Questions
+## Unresolved Questions
 
 None.

--- a/text/0024-crust-refactor/nat-traversal-library.md
+++ b/text/0024-crust-refactor/nat-traversal-library.md
@@ -7,18 +7,18 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 Create a separate library for NAT traversal techniques.
 
-# Motivation
+## Motivation
 
 The MaidSAFE network needs to be able to operate through NATs. Currently NAT
 traversal is implemented in Crust, however these techniques may be useful
 elsewhere and to other Rust developers. We can achieve better separation of
 concerns by implementing a generic NAT-traversal library as a separate crate.
 
-# Detailed design
+## Detailed design
 
 The actual techniques used in this library are described in [RFC-008 UDP Hole Punching](https://github.com/maidsafe/rfcs/tree/master/active/0008-UDP-hole-punching).
 
@@ -209,15 +209,15 @@ let PunchedUdpSocket { socket, peer_addr } = punched_udp_socket;
 // can be used to talk to `peer_addr` through NATs and firewalls.
 ```
 
-# Drawbacks
+## Drawbacks
 
 I can't see a reason not to do this.
 
-# Alternatives
+## Alternatives
 
 Not do this.
 
-# Unresolved questions
+## Unresolved questions
 
 What other existing techniques are there for NAT traversal? Is this API
 actually forward-compatible if we wish to add these techniques in the future?

--- a/text/0025-launcher-direct-data-api/0025-launcher-direct-data-api.md
+++ b/text/0025-launcher-direct-data-api/0025-launcher-direct-data-api.md
@@ -10,14 +10,14 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 Add `self_encryptor` data IO to `safe_ffi` and `safe_launcher` API.
 
 Currently NFS is exposed via `safe_ffi` and the `safe_launcher` REST API which uses self encryption under the hood. This
 RFC is to provide direct access to `self_encryption` for those that don't need/want full file system structures.
 
-# Motivation
+## Motivation
 
 App developers will need to directly write self-encrypted chunks to the network and receive a data map back with
 information about the chunks. While the Rust lib can be used directly, by exposing it via the launcher REST service
@@ -30,13 +30,13 @@ for those that don't need that extra metadata.
 This is the self-encryption equivalent of [the issue](https://github.com/maidsafe/rfcs/issues/77) for supporting core
 data types via the launcher API.
 
-# Detailed design
+## Detailed design
 
 This design will center around how the `safe_launcher` HTTP API will look. This obviously implies that the operations
 need to be exposed via `safe_ffi`. This should be considered an advanced API and documentation for it should carry a
 disclaimer encouraging devs to use NFS if they can.
 
-## Self-Encrypted Data Identifier
+### Self-Encrypted Data Identifier
 
 In order for data to be accessed, a data map must be provided. This can be seen as an identifier to the data. The data
 map will be a base 64'd JSON structure. Several options for passing the data map were considered. The size can get
@@ -98,9 +98,9 @@ launcher would use TLS instead of rolling its own).
 Of course, `safe_ffi` can accept more proper data structures and the decoding/deserialization of the data map can just
 be part of the HTTP API.
 
-## HTTP Calls
+### HTTP Calls
 
-### GET /data/:dataMapIdentifier?offset=123&length=123
+#### GET /data/:dataMapIdentifier?offset=123&length=123
 
 Obtain a self encrypted set of data. The data map identifier may be part of the path or it may be sent in the HTTP
 header `Safe-Data-Map`. If they are both present and don't match or if neither are present, a 400 error is returned with
@@ -115,7 +115,7 @@ The query parameter `offset` is optional and defaults to 0. The query parameter 
 full length. Ideally these would be proper HTTP `Range` headers but they are in the query string to be consistent with
 `GET /nfs/file` (which arguably should be using proper HTTP semantics here and not the query string).
 
-### POST /data/:dataMapIdentifier?offset=123
+#### POST /data/:dataMapIdentifier?offset=123
 
 Write a self encrypted set of data. If this is editing an existing data piece, the data map identifier may be part of
 the path or it may be sent in the HTTP header `Safe-Data-Map`. If they are both present and don't match it is a 400
@@ -138,7 +138,7 @@ The reason POST was chosen is that despite the existing service using a combinat
 method for creating/updating. Also since the data map changes upon write the URL does not represent an unchanging
 RESTful resource URL, POST is more appropriate than PUT.
 
-# Drawbacks
+## Drawbacks
 
 Reasons why not:
 
@@ -147,12 +147,12 @@ Reasons why not:
 1. The Maidsafe devs do not want people leveraging the low level data persistence over HTTP (and thereby possibly
    avoiding the GPL).
 
-# Alternatives
+## Alternatives
 
 1. Do TLS properly on the API so we can stream data back and forth instead of whole-body NACL crypto
 1. Use proper HTTP `Range` headers instead of the primitive query string approach
 
-# Unresolved questions
+## Unresolved questions
 
 1. Should we expose truncate?
 1. Should we expose raw encrypt/decrypt just in case devs wanted to encrypt some data for the user for other uses?

--- a/text/0026-crust-mock/0026-crust-mock.md
+++ b/text/0026-crust-mock/0026-crust-mock.md
@@ -7,23 +7,23 @@
 - RFC PR:
 - Issue number:
 
-# Summary
+## Summary
 
 Drop-in mock replacement for Crust to make it easier to unit test libraries and applications that use Crust.
 
-# Motivation
+## Motivation
 
 Testing Crust-depending libraries on real network (even on LAN or localhost) is cumbersome, slow and potentially expensive. A drop in mock replacement for Crust could make these test simpler and faster, make it easier to diagnose failures, and help cover edge cases difficult to set up on real network.
 
-# Detailed design
+## Detailed design
 
 This section details one possible implementation of the Crust Mock.
 
-## Changes to routing
+### Changes to routing
 
 Add a feature gate which when enabled will replace `crust::Service` with the mock version. There might be need to replace other types with mock version. One potential candidate is `crust::OutConnectionInfo`.
 
-## Features of `crust::mock::Service`
+### Features of `crust::mock::Service`
 
 - Do not hit real network (not even LAN or localhost), do not use TCP/UDP sockets.
 - Simulate all the relevant config files crust uses (crust config, bootstrap cache, etc...). Possibly by accepting structs, representing those configs, as parameters to the constructor.
@@ -33,41 +33,41 @@ Add a feature gate which when enabled will replace `crust::Service` with the moc
 - OPTIONALLY: intercept and examine messages sent over the simulated network
 - OPTIONALLY: ability to set expectations of various network events and verify that they really occurred.
 
-## Implementation details
+### Implementation details
 
 Refer to the `implementation-sketch.rs` file in the same directory as this document.
 
-## Additional notes
+### Additional notes
 
 Although this should eventually become part of crust crate, it might make things easier to initially start developing it as part of routing. Then, routing unit tests utilizing it could be written in parallel, serving double role as tests for routing and sanity checks for the mock service. After it sufficiently stabilizes, it can be extracted and incorporated into crust.
 
-# Drawbacks
+## Drawbacks
 
 TODO (Why should we *not* do this?)
 
-# Alternatives
+## Alternatives
 
-## Do not mock crust, mock the lower layers (TCP/UDP protocol) instead.
+### Do not mock crust, mock the lower layers (TCP/UDP protocol) instead.
 
 Advantage of this is that there might be existing solution for this (TODO: investigate them). Disadvantage is that it might be too low-level for out purposes. For example, we would have to deal with things like hole-punching which are not interesting for the upper layers. On the other hand, it would be possible to use this to unit-test crust itself (but that is out of scope of this RFC).
 
-## Testing on real network
+### Testing on real network
 
 Closest to actual usage, but very slow, unpredictable, potentially expensive and cumbersome to diagnose.
 
-## Testing on local network
+### Testing on local network
 
 Faster than on real network, but getting sufficient number of physical machines might be expensive. Difficult to test connection failures and other error situations (as LANs tend to be more reliable than real networks). Still slow and cumbersome to diagnose.
 
-## Testing on localhost
+### Testing on localhost
 
 Tricky to test large networks as they tent to exhaust hardware resources (CPU, RAM), making testing slow and unpredictable. Diagnosis is still slow and cumbersome.
 
-## Conditional compilation instead of trait
+### Conditional compilation instead of trait
 
 This is an alternative to defining the `ConnectionService` trait with two implementation (real and mock). Instead, the `#[cfg(test)]` attribute would be used to control whether to use the real `crust::Service` or the mocked one. We would still need the ability to pass a service-returning lambda to `routing::Core` to be able to pass fake config files, etc... to the mock service. That could be test only too.
 
 
-# Unresolved questions
+## Unresolved questions
 
 None so far.

--- a/text/0027-append-by-all-structured-data-type/0027-append-by-all-structured-data-type.md
+++ b/text/0027-append-by-all-structured-data-type/0027-append-by-all-structured-data-type.md
@@ -8,13 +8,13 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 The proposal details on how a new Structured Data Type which can be appended by all
 can enable dynamic data handling.
 
 
-# Motivation
+## Motivation
 
 Currently the SAFE Network supports static data storage and retrieval. This limits
 potential application developers to building only static applications and in real world the majority
@@ -22,7 +22,7 @@ of applications are dynamic in nature. Enabling dynamic data handling will allow
 developers to create and manage their own data structures using Structured Data and Immutable Data
 from the SAFE Network.
 
-# Detailed Design
+## Detailed Design
 
 Structured data at present can only be modified by the owner. If it has multiple owners,
 then at least (n/2) + 1 owners must sign the Structured Data for any update or delete.
@@ -43,12 +43,12 @@ from the Launcher. The applications must request `LOW_LEVEL_API_ACCESS` permissi
 authorisation for invoking the low level APIs for Structured Data and
 Immutable Data access.
 
-## A Practical Use Case - Simple Forum Application
+### A Practical Use Case - Simple Forum Application
 
 The appendable Structured Data and Immutable Data can be used to create a dynamic
 application like a `Forum`.
 
-### Hosting the Application - Same as we do for the static websites
+#### Hosting the Application - Same as we do for the static websites
 
 - The admin of the application creates a public name and a service name. Let us consider,
 that the service name is `forum` and the public name is `maidsafe`, making it accessible
@@ -56,7 +56,7 @@ from a browser as `http://forum.maidsafe.net`
 - The application is hosted on the SAFE Network just like a website is hosted by mapping
 the public folder (source of the application) with the service.
 
-### Initial Configuration - Creating Root / Master Appendable Structured Data
+#### Initial Configuration - Creating Root / Master Appendable Structured Data
 
 - After making the application public, the admin registers themselves as the owner / admin of the
 application.
@@ -83,27 +83,27 @@ for identifying the root Structured Data.
 - The hash of service name and public name can be used as the ID for the root / master Structured
 Data.
 
-#### Summing it up
+##### Summing it up
 
 When the admin configures the application for the first time. The application will create a root
 Structured Data with `tag_type as 8` and with id `SHA512(service name + public name)`.
 The data part of the Structured Data can be anything that would fit the needs of the application
 like, `csv, toml, json` etc. In this use case we will be using a JSON object.
 
-#### Application looking up for the master Structured Data on start
+##### Application looking up for the master Structured Data on start
 
 When a user reaches the end point (forum.maidsafe.safenet), the application will be able to lookup
 the Structured Data with the id `SHA512(service name + public name)`. Once the data is retrieved,
 based on the JSON object the rest of the data needed by the application can be fetched.
 
-#### When a new thread is created
+##### When a new thread is created
 
 Say user ABC has set up the forum and they become the admin. Now, let consider user XYZ wants to
 create a new thread. When a new thread is created, the data related to the thread is stored in the
 network as a JSON object in the form of Immutable Data chunks. The DataMap of the thread will be
 added to the root / master Structured Data.
 
-##### Detailing the steps in sequence
+###### Detailing the steps in sequence
 
 - User XYZ logs in to the Launcher with their own credentials and goes to `forum.maidsafe.safenet`
 - Application will look up for the master / root Structured Data by hashing the service and long
@@ -131,7 +131,7 @@ New DataMap is added to the posts list in the root Structured Data.
   "replies": []
 }
 ```
-##### When a reply is made to a post
+###### When a reply is made to a post
 
 When other users reply to the thread, a new DataMap can be generated and updated in the root /
 master Structured Data.
@@ -144,7 +144,7 @@ master Structured Data.
 Here v2 represents the new DataMap.
 
 
-# Drawbacks
+## Drawbacks
 
 Since the root / master Structured Data is generated / looked up in a deterministic manner
 and moreover it can also be appended by anyone, this makes it easier for an attacker to corrupt
@@ -154,11 +154,11 @@ DNS also uses a deterministic approach, but the Structured Data is secure as it 
 by the owner. But in this appendable Structured Data, it becomes easier to corrupt the data.
 
 
-# Alternatives
+## Alternatives
 
 None
 
-# Unresolved Questions
+## Unresolved Questions
 
 Concurrency Issue: When two users are replying to a same thread at the same time.
 Only the last updated DataMap will be reflected. This will result in the loss of the

--- a/text/0030-secure-node-join/0030-secure-node-join.md
+++ b/text/0030-secure-node-join/0030-secure-node-join.md
@@ -8,11 +8,11 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 Securely join a node to network
 
-# Motivation
+## Motivation
 
 Currently node relocation involves a convoluted mechanism that ends with a non cryptographically
 validatable Id. A much more secure mechanism will ensure group membership is easily confirmed as
@@ -22,7 +22,7 @@ network to confirm they are in fact network connected nodes. This is achieved by
 to a group that is encrypted for a single group member. Only the member can read the message and
 reply.
 
-# Detailed design
+## Detailed design
 
 
 In the current implementation as seen in this sequence diagram XXXXX involves several steps. This
@@ -47,14 +47,14 @@ Node (A) will then have and ID that is cryptographically validated and allow the
 much more flexibility in handling requests and data for node A.
 
 
-# Drawbacks
+## Drawbacks
 
 None known at this time.
 
-# Alternatives
+## Alternatives
 
 The status quo does indeed work, but loses cryptographic guarantees that this scheme offers.
 
-# Unresolved questions
+## Unresolved questions
 
 TBD

--- a/text/0033-fake-account-packet/0033-fake-account-packet.md
+++ b/text/0033-fake-account-packet/0033-fake-account-packet.md
@@ -8,12 +8,12 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 This proposes an enhancement whereby the network will respond to a `Get` request for a non-existent
 account packet (`StructuredData` with `type_tag` 0) with a fake account packet.
 
-# Motivation
+## Motivation
 
 The objective is to deter an attack where random account packets are requested by a malicious Client
 in the hopes of finding one in order to attempt decryption of it.
@@ -22,9 +22,9 @@ The defence is to have the network respond to requests for non-existent account 
 which will appear valid to the recipient.  This will make it expensive for the attacker, since it
 won't know whether the decrypted packet will yield useful data or not.
 
-# Detailed design
+## Detailed design
 
-## Issues to Overcome
+### Issues to Overcome
 
 The main issue is to be able to have a group of Vaults agree a fake packet which will be accumulated
 by the attacker - i.e. the group all need to generate an identical fake.  Essentially we just need a
@@ -41,7 +41,7 @@ list of Vault names.  It would then be easy to deduce that the responses contain
 A more trivial issue is that while account packets are currently the highest-value targets for an
 attacker, it should be possible to extend the defence to other `StructuredData` types easily.
 
-## Proposed Solution
+### Proposed Solution
 
 There is an example implementation at https://gitlab.com/Fraser999/Fake-Account-Packet.
 
@@ -179,7 +179,7 @@ fn create_fake_account_packet(id: XorName, session_ids: &[SessionId]) -> Structu
 }
 ```
 
-# Drawbacks
+## Drawbacks
 
 This presents a very basic implementation.  It requires the Vaults to generate throwaway
 cryptographic keys in order to create a plausible fake - a relatively expensive operation.  For an
@@ -188,7 +188,7 @@ proposed defence may need to become more complex, e.g. monitoring and reacting t
 rates of `Get` requests for non-existent data, or caching spare throwaway crypto keys during quiet
 periods for later use in generating fakes.
 
-# Alternatives
+## Alternatives
 
 1. Don't respond to `Get` requests for non-existent data.  While this would be simple to implement
 in Vaults and would be the optimal way to avoid allowing an attacker to make Vaults "do work", it
@@ -202,7 +202,7 @@ passing by.  This would need to be handled by the Vault through which the Client
 an unacceptably high rate of `GetFailure`s is reached, the Client is dropped.  This seems fairly
 simple to implement, but an attacker would be able to work around this by using many Clients.
 
-# Unresolved questions
+## Unresolved questions
 
 1. Should the seed be generated using all members' names from the close group, or just a subset of
 closest ones?

--- a/text/0034-immutable-data-name-function/0034-immutable-data-name-function.md
+++ b/text/0034-immutable-data-name-function/0034-immutable-data-name-function.md
@@ -8,11 +8,11 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 This RFC proposes some alternative implementations for `ImmutableData::name()`.
 
-# Motivation
+## Motivation
 
 The existing `ImmutableData::name()` function is highly inefficient as it performs a SHA512 hash
 operation on every call.  It has to do this since it doesn't have a `name` member variable.  This
@@ -39,7 +39,7 @@ The proposed alternatives are:
   an instance of `ImmutableData` guaranteeing that `ImmutableData` instances will always be valid,
   uncorrupted chunks
 
-## Comparison
+### Comparison
 
 | Type          | Can be Invalid | Contents Hashed        | Needs Custom Encode Functions <sup>1</sup> | Can Derive `Ord`, `PartialOrd` and `Hash` |
 |:--------------|:---------------|:-----------------------|:-------------------------------------------|:------------------------------------------|
@@ -51,12 +51,12 @@ The proposed alternatives are:
 1: We can't use the `serialise()` and `deserialise()` functions from maidsafe_utilities for any that
 need custom encode functions, as they won't implement the required traits.
 
-# Detailed design
+## Detailed design
 
 There is an example implementation along with tests and benchmark code at
 https://gitlab.com/Fraser999/DataName.
 
-## <a name="Existing"></a>Existing Implementation
+### <a name="Existing"></a>Existing Implementation
 
 For comparison, the existing (abbreviated) implementation of `ImmutableData` is:
 
@@ -83,7 +83,7 @@ impl ImmutableData {
 
 ---
 
-## <a name="Lazy"></a>Lazy Implementation
+### <a name="Lazy"></a>Lazy Implementation
 
 ```rust
 #[derive(Clone, Eq, PartialEq)]
@@ -139,7 +139,7 @@ impl Decodable for ImmutableData {
 
 ---
 
-## <a name="Minimal"></a>Minimal Implementation
+### <a name="Minimal"></a>Minimal Implementation
 
 ```rust
 #[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -189,7 +189,7 @@ impl Decodable for ImmutableData {
 
 ---
 
-## <a name="Safe"></a>Safe Implementation
+### <a name="Safe"></a>Safe Implementation
 
 ```rust
 #[derive(Hash, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -253,7 +253,7 @@ impl From<SerialisationError> for DataError {
 
 ---
 
-## Sample Benchmarks for 1MB Chunks
+### Sample Benchmarks for 1MB Chunks
 
 These results are from a 64-bit Windows 10 machine with an Intel Core i7-4790K and 8GB RAM.
 
@@ -264,15 +264,15 @@ These results are from a 64-bit Windows 10 machine with an Intel Core i7-4790K a
 | [Minimal][2]  |         0 ns/iter (+/- 1)      | 2,314,490 ns/iter (+/- 29,752)  | 8,081,331 ns/iter (+/- 183,989) |
 | [Safe][3]     |         0 ns/iter (+/- 0)      | 3,026,149 ns/iter (+/- 89,004)  | 7,237,680 ns/iter (+/- 108,792) |
 
-# Drawbacks
+## Drawbacks
 
 None over existing implementation.
 
-# Alternatives
+## Alternatives
 
 None.
 
-# Unresolved questions
+## Unresolved questions
 
 Which of the alternatives should be used?
 

--- a/text/0035-routing-message-acknowledgements/0035-routing-message-acknowledgements.md
+++ b/text/0035-routing-message-acknowledgements/0035-routing-message-acknowledgements.md
@@ -8,12 +8,12 @@
 - Supersedes:
 - Superseded by:
 
-# Summary
+## Summary
 
 This RFC proposes that Routing's parallel message sending mechanism is replaced by a message
 acknowledgement (ack) mechanism.
 
-# Motivation
+## Motivation
 
 Routing currently implements sending messages via eight parallel routes for reliability and security
 reasons.  While the routes for a given message will likely converge as the message nears its
@@ -22,7 +22,7 @@ Routing nodes.
 
 The proposed ack mechanism should allow these costs to be reduced significantly.
 
-# Detailed design
+## Detailed design
 
 Rather than a message being sent via parallel routes, instead it will be sent via a single route and
 will require an ack to be sent by the recipient(s).  Should an ack *not* be received within a
@@ -74,17 +74,17 @@ pub enum ResponseContent {
 
 As above, the value will be the SipHash of the received `SignedMessage`.
 
-# Drawbacks
+## Drawbacks
 
 This is a less secure mechanism.  However, the security concerns will be addressed in a future RFC.
 
-# Alternatives
+## Alternatives
 
 There are some possible improvements which are not being considered at the moment in the interests
 of simplicity.  Some ideas which have surfaced are:
 * variable timeouts depending on the distance the message has to travel and/or the size of message
 * selective acks - not all messages need acknowledged
 
-# Unresolved questions
+## Unresolved questions
 
 None.

--- a/text/0036-launcher-api-v0.5/0036-launcher-api-v0.5.md
+++ b/text/0036-launcher-api-v0.5/0036-launcher-api-v0.5.md
@@ -1,6 +1,6 @@
 # safe_launcher API v0.5
 
-- Status: proposed
+- Status: active
 - Type: new feature, enhancement
 - Related components: safe_launcher
 - Start Date: 25-05-2016


### PR DESCRIPTION
The readme in the root of the rfc repo says

The first line "should be the only first-degree headline in the entire RFC!"

There were a lot of other first-degree headlines so I changed the depth in by one for all headings that were not on the first line.

This was not possible for rfcs which were already utilizing the maximum headline depth, namely 0016 0018 0028 and 0036.

I know this pull request seems like 'busy work' but correct headings is

* the correct procedure
* better for SEO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/rfcs/151)
<!-- Reviewable:end -->
