### PR TITLE
update to ImmutableData low level api

### DIFF
--- a/text/0042-launcher-api-v0.6/api/immutable_data.md
+++ b/text/0042-launcher-api-v0.6/api/immutable_data.md
@@ -69,34 +69,6 @@ Authorization: Bearer <TOKEN>
 Binary data
 ```
 
-
-## Close Immutable Data Reader
-
-Unauthorised access is allowed.
-
-### Request
-
-#### Endpoint
-
-```
-DELETE /immutable-data/reader/{Reader-Handle-Id}
-```
-
-#### Headers
-
-```
-Authorization: Bearer <TOKEN>
-```
-
-### Response
-
-#### Status Code
-
-```
-200 or 206
-```
-
-
 ## Get ImmutableData Writer
 
 ### Request
@@ -164,14 +136,65 @@ Binary data
 
 ## Close Immutable Data Writer
 
-Invoking close on writer will generate the DataMap and return the DataIdentifier handle.
+Invoking close on writer will generate the DataMap and save it to the network and
+return the DataIdentifier handle which can be used to read the data.
 
 ### Request
 
 #### Endpoint
 
 ```
-DELETE /immutable-data/writer/{Writer-Handle-Id}/{cipher-opts-handle}
+PUT /immutable-data/writer/{Writer-Handle-Id}/{cipher-opts-handle}
+```
+
+#### Headers
+
+```
+Authorization: Bearer <TOKEN>
+```
+
+### Response
+
+#### Status Code
+
+```
+200
+```
+
+## Drop Immutable Data Reader
+
+Unauthorised access is allowed.
+
+### Request
+
+#### Endpoint
+
+```
+DELETE /immutable-data/reader/{Reader-Handle-Id}
+```
+
+#### Headers
+
+```
+Authorization: Bearer <TOKEN>
+```
+
+### Response
+
+#### Status Code
+
+```
+200
+```
+
+## Drop Immutable Data Writer
+
+### Request
+
+#### Endpoint
+
+```
+DELETE /immutable-data/writer/{Writer-Handle-Id}
 ```
 
 #### Headers

--- a/text/0042-launcher-api-v0.6/api/immutable_data.md
+++ b/text/0042-launcher-api-v0.6/api/immutable_data.md
@@ -144,7 +144,7 @@ return the DataIdentifier handle which can be used to read the data.
 #### Endpoint
 
 ```
-PUT /immutable-data/writer/{Writer-Handle-Id}/{cipher-opts-handle}
+PUT /immutable-data/{Writer-Handle-Id}/{cipher-opts-handle}
 ```
 
 #### Headers


### PR DESCRIPTION
Previously close writer was mapped to `DELETE`. To make it consistent with other low level apis changed the following

- Close writer function changed to `PUT`
- Drop handle endpoints added for dropping reader and writer handles

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/rfcs/193)
<!-- Reviewable:end -->
