### PR TITLE
Regenerate the status document and add CI to fail if it needs updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: bash
+
+script:
+  - bash test_rfc_status.sh

--- a/RFCs-by-status.md
+++ b/RFCs-by-status.md
@@ -6,9 +6,7 @@ A list of all RFCs by their current status.
 
  - [#0030 Nodes key as name](./text/0030-secure-node-join/0030-nodes_key_as_name.md)
  - [#0037 Disjoint Sections](./text/0037-disjoint-groups/0037-disjoint-groups.md)
- - [#0043 Async safe_core](./text/0043-async-safe-core/0043-async-safe-core.md)
  - [#0046 New Auth Flow](./text/0046-new-auth-flow/0046-new-auth-flow.md)
- - [#0047 MutableData](./text/0047-mutable-data/0047-mutable-data.md)
  - [#0048 Authorise apps on behalf of the owner to mutate data](./text/0048-authorise-apps/0048-authorise-apps.md)
 
 ## Proposed RFCs
@@ -49,6 +47,8 @@ A list of all RFCs by their current status.
  - [#0040 Unify Structured Data](./text/0040-unified-structured-data/0040-unified-structured-data.md)
  - [#0041 Low Level API](./text/0041-low-level-api/0041-low-level-api.md)
  - [#0042 SAFE Launcher API v0.6](./text/0042-launcher-api-v0.6/0042-launcher-api-v0.6.md)
+ - [#0043 Async safe_core](./text/0043-async-safe-core/0043-async-safe-core.md)
+ - [#0047 MutableData](./text/0047-mutable-data/0047-mutable-data.md)
 
 ## Rejected RFCs
 
@@ -68,4 +68,4 @@ A list of all RFCs by their current status.
  - [#0044 Relay Nodes](./text/0044-relay-nodes/0044-relay-nodes.md)
 
 
-(Last updated _Thu  4 Apr 10:04:32 BST 2019_ at REV [942ce39](https://github.com/maidsafe/rfcs/commit/942ce399b6a4d20a385026f4b308dd0c775e3faa))
+(Last updated _Thu  4 Apr 2019 14:13:55 BST_ at REV [b665e23](https://github.com/maidsafe/rfcs/commit/b665e23add833e0486b4817e260a6df4272f8524))

--- a/test_rfc_status.sh
+++ b/test_rfc_status.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+./generate_by_status.sh > generated
+diff generated RFCs-by-status.md | wc -l > new_lines
+count=`cat new_lines`
+
+rm generated
+rm new_lines
+echo "number of changes to the RFCs-by-status.md = $count"
+
+# if the differences aren't only the timestamp (4 lines) then exit code 1
+if [ $count -ne 4 ]
+then
+  #fail
+  echo "This has failed because it appears that there has been a change to a"
+  echo "RFC document status, which has not been reflected in your PR."
+  echo "Please run the generate_by_status.sh script and commit the updates"
+  echo "as part of your PR"
+  exit 1
+fi


### PR DESCRIPTION
To regenerate the `RFCs-by-status.md` I ran:
```
./generate_by_status.sh > RFCs-by-status.md
```

I've also added a .travis.yml file which checks to see if any document status does not match the `RFCs-by-status.md`, and so forcing the author to add a commit to the PR to run the update. If CI fails it will provide a helpful message, as below:
![image](https://user-images.githubusercontent.com/37112040/55621380-3a37f480-5795-11e9-8f83-94b15c7df143.png)
