### PR TITLE
RFC 54: fix issues in the data type RFC

### DIFF
--- a/text/0054-published-and-unpublished-data/0054-published-and-unpublished-data.md
+++ b/text/0054-published-and-unpublished-data/0054-published-and-unpublished-data.md
@@ -202,7 +202,6 @@ struct Owners {
 pub enum PublicKey {
     // To be defined by the implementation.
     // Can be a BLS public key, for example.
-
 }
 ```
 
@@ -386,7 +385,6 @@ pub enum Request {
         // Get first 5 entries:
         // range: (Range::Index(0), Range::Index(5))
         range: (Range, Range),
-
     },
 
     // Get current indexes: data, owners, permissions.
@@ -632,25 +630,16 @@ pub enum Response {
     GetADataPermissions(Result<Permissions, ClientError>),
     GetADataUserPermissions(Result<BTreeSet<Permission>, ClientError>),
     GetADataOwners(Result<Owners, ClientError>),
-    AddADataPermissions(Result<(), ClientError>),
     GetADataValue(Result<Vec<u8>, ClientError>),
-    SetADataOwners(Result<(), ClientError>) {
-    AppendPublishedSeq(Result<(), ClientError>),
-    AppendUnpublishedSeq(Result<(), ClientError>),
     // Returns a last data index.
     AppendPublishedUnsequenced(Result<u64, ClientError>),
     // Returns a last data index.
     AppendUnpublishedUnsequenced(Result<u64, ClientError>),
-    PutAData(Result<(), ClientError>),
     GetADataShell(Result<AppendOnlyData, ClientError>),
-    DeleteUnseqAData(Result<(), ClientError>),
-    DeleteSeqAData(Result<(), ClientError>),
 
     // ===== Mutable Data =====
     GetUnseqMData(Result<UnsequencedMutableData, ClientError>),
     GetSeqMData(Result<SequencedMutableData, ClientError>),
-    PutUnseqMData(Result<(), ClientError>),
-    PutSeqMData(Result<(), ClientError>),
     GetMDataVersion(Result<u64, ClientError>),
     GetUnseqMDataShell(Result<UnsequencedMutableData, ClientError>),
     GetSeqMDataShell(Result<SequencedMutableData, ClientError>),
@@ -661,12 +650,10 @@ pub enum Response {
     ListSeqMDataValues(Result<Vec<Value>, ClientError>),
     GetUnseqMDataValue(Result<Vec<u8>, ClientError>),
     GetSeqMDataValue(Result<Value, ClientError>),
-    MutateMDataEntries(Result<(), ClientError>),
     ListMDataPermissions(Result<BTreeMap<PublicKey, BTreeSet<MDataPermission>>>),
     ListMDataUserPermissions(Result<BTreeSet<MDataPermission>>),
-    SetMDataUserPermissions(Result<(), ClientError>),
-    DelMDataUserPermissions(Result<(), ClientError>),
-    ChangeMDataOwner(Result<(), ClientError>),
+    // Common to all mutation operations
+    Mutation(Result<(), ClientError>),
 }
 ```
 

--- a/text/0055-unpublished-immutable-data/0055-unpublished-immutable-data.md
+++ b/text/0055-unpublished-immutable-data/0055-unpublished-immutable-data.md
@@ -19,7 +19,7 @@ This document describes how to enhance `ImmutableData` to make it an unpublished
 There are many a times when we create `ImmutableData` to store private content. Sometimes these contents might have been pre-encrypted so that any chances of having de-duplication due to self-encryption is very minimal. Also the users might not choose to utilise self-encryption and just use custom algorithms. In such cases it makes sense if the Network allowed deletion of `ImmutableData` instead of it storing many of them which might no longer be required even by the original uploader. However all such data will be regarded as unpublished as opposed to current `ImmutableData` which will be categorised as published and cannot be taken out once put.
 
 ## Assumptions
-- As mentioned in the [RFC on MutableData enhancements](https://github.com/maidsafe/pre-rfc/blob/master/vault/mutable-data-enhancement.md), the `GETs` go through `ManidManagers` - so `clients <-> MaidManagers <-> DataManagers`
+- As mentioned in the [RFC on MutableData enhancements](https://github.com/maidsafe/pre-rfc/blob/master/vault/mutable-data-enhancement.md), the `GETs` go through `MaidManagers` - so `clients <-> MaidManagers <-> DataManagers`
 - The replay attacks are circumvented by the (currently upcoming) safe-coin RFC.
 
 ## Detailed design
@@ -38,7 +38,7 @@ pub struct UnpublishedImmutableData {
     /// Contains a set of owners of this data. DataManagers enforce that a
     /// DELETE or OWNED-GET type of request is coming from the
     /// MaidManager Authority of the owners.
-    owners: BLS-PublicKey,
+    owners: PublicKey,
 }
 
 impl UnpublishedImmutableData {
@@ -47,6 +47,12 @@ impl UnpublishedImmutableData {
         let c = CONCAT(HASH(self.data), self.owner);
         HASH(c)
     }
+}
+
+pub enum PublicKey {
+    // To be defined by the implementation.
+    // Can be a BLS public key, for example.
+
 }
 ```
 - In summary, the only RPCs allowed for such a data type SHALL be `PUT` (to create), `OWNED-GET` (to retrieve) and `DELETE`, all done by the owner(s).

--- a/text/0055-unpublished-immutable-data/0055-unpublished-immutable-data.md
+++ b/text/0055-unpublished-immutable-data/0055-unpublished-immutable-data.md
@@ -52,7 +52,6 @@ impl UnpublishedImmutableData {
 pub enum PublicKey {
     // To be defined by the implementation.
     // Can be a BLS public key, for example.
-
 }
 ```
 - In summary, the only RPCs allowed for such a data type SHALL be `PUT` (to create), `OWNED-GET` (to retrieve) and `DELETE`, all done by the owner(s).


### PR DESCRIPTION
[Rendered](https://github.com/lionel1704/rfcs/blob/rfc-update/text/0054-published-and-unpublished-data/0054-published-and-unpublished-data.md)

- Remove the requester field from the Requests
- Replace BLS-PublicKey with the PublicKey enum
- Add missing RPCs for AppendOnly Data
- Add missing index field for AData owners and permissions manipulation
- Use common response type for mutations

closes #316 
closes #315 
closes #318