### PR TITLE
docs/rfc-0052: extend/alter nomenclature. add recursive resolution

### DIFF
--- a/text/0052-RDF-for-public-name-resolution/0052-RDF-for-public-name-resolution.md
+++ b/text/0052-RDF-for-public-name-resolution/0052-RDF-for-public-name-resolution.md
@@ -14,7 +14,6 @@ This proposal looks to enhance the public name resolution system by using a reso
 
 ## Conventions
 - The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119).
-- XOR-URL refers to a url generated as part of the content addressable system for accessing `xorname` urls in the safe_browser. As described here: https://forum.safedev.org/t/xor-address-urls-xor-urls/1952
 - Data is presented as RDF, serialised in [JSON-LD](https://json-ld.org/) in the examples.
 - I'm using AppendOnlyData, `AOD`, and ImmutableData `ID` as shorthand.
 
@@ -34,17 +33,21 @@ This RFC proposes that url schemes such as `safe://somewhere` can have sub-domai
 ### Nomenclature
 
 -  `Name Resolution System` (NRS) instead of `DNS` to avoid confusion and clarify this is a SAFE network term, and that it relates to `Public Names`.
-	- Here the URL terminology for `host` is equivalent to a SAFE `Public Name`.
-	- What is called `subdomains` on the clearnet are referred to as `Sub Names`.
+	- Here the DNS terminology for `domain` is equivalent to a SAFE `Public Name`.
+	- What is called `top level domain` aka `tld` in DNS is referred to as `Top Name`
+	- What is called `sub domains` in DNS are referred to as `Sub Names`.
 - Introduce `Resolvable Map` schema to describe RDF data on the network that can resolve a given `key` to a XOR-URL. This is described below and can be used by:
 	- `Public Name` AODs.
 	- A `Files Container` AOD: an alternative to the NFS style container, with similar functionality but described using RDF (and the `Resolvable Map` schema)
+- `XOR-URL` refers to a url generated as part of the content addressable system for accessing `xorname` urls in the safe_browser. As described here: <https://forum.safedev.org/t/xor-address-urls-xor-urls/1952>
+- `NRS-URL` indicates a URL that conforms to section 2 of this specification.
+- `SAFE-URL` indicates a URL that is either an XOR-URL or an NRS-URL
 
 ### Versioned Data / The Perpetual Web
 
 NRS data on the network, is by its very nature, public. Which means that it cannot be deleted. This concept forms the basis of the Perpetual Web, where data can only be appended to (using AppendOnlyData). As a consequence RDF data described here is a type of 'versioned' data, with the `key` of an AOD being a `UTC timestamp`, and the `value` of an entry being a string representation of the RDF data. This means that _all versions of the data_ can be accessed (via version `?v=222` url params, [see xorurl rfc for more info](https://forum.safedev.org/t/xor-address-urls-xor-urls/1952), as well as the order of this data, and the timestamp changes were made. (Although these timestamps are applied client side, and therefore are optional so should not be treated with any reverence.)
 
-It's important to note that while XOR-URLs enable accessing versions of the data, NRS urls allow accessing versions of the NRS Container itself. And so in order to facilitate the Perpetual Web and canonical URLs, NRS containers will require that linked data MUST specify a version for the target data.
+It's important to note that while XOR-URLs enable accessing versions of the data, NRS-URLs allow accessing versions of the NRS Container itself. And so in order to facilitate the Perpetual Web and canonical URLs, NRS containers will require that linked data MUST specify a version for the target data.
 
 ### Reference Implementation
 
@@ -64,47 +67,160 @@ If so, it is resolved via XOR-URL.
 - If another data type is found, say a `FilesContainer` or `ImmutableData`, that data is retrieved (see point 3 below).
 
 
-#### 2. PublicNameSystem.
+#### 2. NRS-URL.
 
 Failing to be detected as a XOR-URL, we then parse the url and use the Public Name System to resolve for data.
 
-Here the URL terminology for `host` is equivalent to a SAFE `Public Name`. What are known as `subdomains` on the clearnet are referred to as `SubNames`.
+Here the DNS terminology for `domain` is equivalent to a SAFE `Public Name`. What is known as `top level domain` in DNS is referred to as `Top Name`. What are known as `sub domains` in DNS are referred to as `Sub Names`.
 
-`safe://<subName>.<publicName>?v=<version>`
+```
+safe://<subName>.<topName>?v=<version>
+       |-----------------|
+            Public Name
+```			
 
-- GET the AppendOnlyData for a given `Public Name`, at the specified `version`.
+```
+Example:
+  Public Name -->  a.myname
+  Top Name    -->  myname
+  Sub Names   -->  a
+```
+
+```
+Example without subnames:
+  Public Name -->  myname
+  Top Name    -->  myname
+  Sub Names   -->  <empty>
+```
+
+- GET the AppendOnlyData for a given `topName`, at the specified `version`.
 - Parse the retrieved `Resolvable Map`.
-- Resolve the `Sub Name` graph from this `Resolvable Map`.
+- Resolve the `Sub Name` graph / SAFE-URL from this `Resolvable Map`.
 
 Unavailability of any data being dereferenced will throw an error.
 
 ##### 2.1 No `SubName` aka Default Services.
 
-- GET the AppendOnlyData for a given `Public Name`.
+- GET the AppendOnlyData for a given `Top Name`.
 - Parse the retrieved `Resolvable Map`.
-- Resolve the `default` graph / XOR-URL if available.
+- Resolve the `default` graph / SAFE-URL if available.
 
 Unavailability of any data being dereferenced will throw an error.
 
 
 ##### 2.2 Many `SubName`s
 
-`safe://<subName>.<subName>.<subName>.<subName>.<publicName>`
+```
+safe://<subName>.<subName>.<subName>.<subName>.<topName>
+       |-----------------------------------------------|
+		          Public Name
+```
+
+```
+Example:
+  Public Name -->  a.b.c.d.myname
+  Top Name    -->  myname
+  Sub Names   -->  a.b.c.d
+```
 
 - As above, resolving each additional substring, up to a defined maximum of redirects (implemented in the resolver.)
 	- Safe Browser will implement redirect limit of 10 redirects per url resolution. Any more than this would throw an error.
 
 Unavailability of any data being dereferenced will throw an error.
 
+#### 3. Path and Version resolution
 
-#### 3. `FilesMap` and `Path` resolution
+Herein, `v_param` refers to the version query-string parameter `?v=`.
 
-`safe://<subName>.<publicName><path>`, eg `safe://pns.rfc/resolution`
+When resolving NRS-URL `link` to SAFE-URL `target`:
 
-Once the final data has been resolved, if a `Files Container` type of `Resolvable Map` has been located, then the trailing url path would be resolved from that `FilesContainer`, too.
+1. the path of `link` is appended to the path of `target`.
+2. the v_param of `link` (if any) is used to lookup matching 
+version of the NrsMap that corresponds to `Top Name` of `link`. If `v_param` is not present, version defaults to latest.
+The `v_param` is not included in resolved URL.
+3. The v_param of `target` is preserved in the resolved URL.
+
+Example: An NRS-URL has just been created with `Top Name` test:
+
+```
+safe://test  --> safe://<xor>/testdata?v=1
+```
+
+The following URLs resolve as:
+
+|url                               | resolves to              |
+|----------------------------------|--------------------------|
+|safe://test                       |safe://&lt;xor>/testdata?v=1 |
+|safe://test?v=0                   |safe://&lt;xor>/testdata?v=1 |
+|safe://test?v=1                   |unresolvable, no version 1 yet for `safe://test`|
+|safe://test/subfolder/sub2.md     |safe://&lt;xor>/testdata/subfolder/sub2.md?v=1 |
+|safe://test/subfolder/sub2.md?v=0 |safe://&lt;xor>/testdata/subfolder/sub2.md?v=1 |
+
+#### 4. Fragment Resolution
+
+The fragment is reserved for use by the client/application.
+
+When resolving NRS-URL `link` to SAFE-URL `target` a fragment in `link` replaces a fragment in `target`.  If `link` has no fragment, but `target` does have a fragment, then the fragment from `target` is preserved.
 
 
-### Data Structures fo Resolution
+Example: An NRS-URL has been created with `Top Name` xmp:
+
+```
+safe://xmp  --> safe://<xor>?v=0#chapter3
+```
+
+The following URLs then resolve as:
+
+|url                              | resolves to              |
+|---------------------------------|--------------------------|
+|safe://xmp | safe://&lt;xor>?v=0#chapter3|
+|safe://xmp#chapter2              | safe://&lt;xor>?v=0#chapter2|
+
+
+#### 5. Recursive NRS-URL Resolution
+
+Each NRS-URL should resolve to a SAFE-URL `target`.
+
+* If `target` is a `XOR-URL` then resolution is complete.
+* If `target` is a `NRS-URL` then `target` should also be resolved, 
+unless the maximum of 10 resolution steps has been reached.
+
+Example: The following NRS-URLs have been created with `Top Names` `test` and `sub`:
+
+```
+safe://test?v=1  --> safe://<xorname>/testdata?v=0
+safe://sub?v=5   --> safe://test/subfolder?v=1
+```
+
+This URL then resolves (after recursion) as:
+
+```
+safe://sub/sub2.md?v=5  --> safe://<xorname>/testdata/subfolder/sub2.md?v=0
+```
+
+
+The individual resolution steps were:
+
+```
+1. safe://sub/sub2.md?v=5             --> safe://test/subfolder/sub2.md?v=1
+2. safe://test/subfolder/sub2.md?v=1  --> safe://<xorname>/testdata/subfolder/sub2.md?v=0
+```
+
+### SAFE-URL Reserved Query String Parameters
+
+The following query-string parameters are reserved for present or future use by the safe network itself, and should not be given application-specific meanings/usages.
+
+These apply to all SAFE-URL, ie both NRS-URL and XOR-URL.
+
+|query-string param|description                                   |
+|------------------|----------------------------------------------|
+|v                 |indicates version of a SAFE Network data type.|
+|safe              |reserved for future use                       |
+|safe-*            |reserved for future use.                      |
+
+note: `safe-*` indicates all valid query-string names that begin with `safe-` prefix.
+
+### Data Structures for Resolution
 
 ![Image of PNS Resolution Data Structures](https://raw.githubusercontent.com/joshuef/rfcs/PnsAndResolveableMap/text/0000-RDF-for-public-name-resolution/PNS_data_representation.png)
 
@@ -122,10 +238,10 @@ Provides data to be shown at the public name.
  - It must be an RDF data object
  `<safe/ResolvableMap>`, `Sub Name` graphs will pointing to a SAFE Url for data location (could be xor or using a subName).
  - Extra data can be added to the graph for each entry to aid in service discovery for the key.
- - `@id` entries _MUST_ point to a versioned XOR-URL for consistency (while pubNames may change, _this_ data will not move location), if a non-versioned link is provided for versioned data the ResolvableMap is considered invalid.
+ - `@id` entries _MUST_ point to a versioned XOR-URL for consistency (while topNames may change, _this_ data will not move location), if a non-versioned link is provided for versioned data the ResolvableMap is considered invalid.
 
 
- For `safe://<subName>.<myPublicName>`
+ For `safe://<subName>.<myTopName>`
 
 
  With the following, `safe://happyurl` would resolve to the `name` graph's entry.
@@ -145,7 +261,7 @@ Provides data to be shown at the public name.
 		  },
 		"@type": "ResolvableItem",
 		"@id": "safe://thisxorurl?v=1#somewhere",
-		"target": "<target graph or safe url (xor or pubName); eg: 'somewhere'>",
+		"target": "<target graph or safe-url; eg: 'somewhere'>",
         "targetType": "FilesMap"
 	},
 	{
@@ -154,7 +270,7 @@ Provides data to be shown at the public name.
 		  },
 		"@type": "ResolvableItem",
 		"@id": "safe://thisxorurl?v=2#email",
-		"target": "<target graph or safe url (xor or pubName); eg: 'email'>",
+		"target": "<target graph or safe-url; eg: 'email'>",
 		"targetType": "http://activitystream/#inbox"
 	}
  ]
@@ -214,12 +330,12 @@ I would propose that we create a `Files Container` RDF type, which follows the s
 
 ```
 
-### PublicName Container Structure
+### Public Name Container Structure
 
 The structure of a user's `_publicNames` container (for managing their `Public Names`) must be:
 
-- The Public Name Map is an RDF AOD w/specific type tag (`1500`) stored at the sha3 hash of the `Public Name` string `shahash3('Public Name')`.
-- A Public Name must point to a `Resolvable Map` RDF schema. With the target AOD location XOR-URL as the value to the key.
+- The `Public Name` Map is an RDF AOD w/specific type tag (`1500`) stored at the sha3 hash of the `Public Name` string `shahash3('Public Name')`.
+- A `Top Name` must point to a `Resolvable Map` RDF schema. With the target AOD location XOR-URL as the value to the key.
 - A user's `Public Names` are saved/managed in the user's `_publicNames` container.
 - A user's `_publicNames` container must be encrypted.
 


### PR DESCRIPTION
First draft of some proposed changes to rfc-0052:

* introduce 'Top Names' nomenclature.
* introduce 'SAFE-URL` nomenclature.
* define 'Public Names' as SubNames + TopNames.  finally consistent with definition as "equivalent" to `host` in a standard URL.
* Add examples for usage of `Public Name`, `Top Name`, `Sub Name`.
* change URL 'host' reference to DNS 'domain', which is a better match
* Re-write Path Resolution section.
* Add a section on resolving recursive NRS-URLs

Note:  I considered naming `Top Name` `Global Name` instead.  This could reflect that it is a name in a truly global namespace.  I went with `Top` because it is shorter to type, and is an easy 1:1 mapping in people's minds with DNS top-level-domain. But if people prefer Global instead, it could be a decent choice.


## A little background:
### The issue: naming inconsistency in RFC-0052.

Let's examine this quote from RFC-0052:

> Here the URL terminology for host is equivalent to a SAFE Public Name. What are known as subdomains on the clearnet are referred to as SubNames.
>
> safe://&lt;subname>.&lt;publicname>?v=&lt;version>

Four interwoven issues arise with the original RFC-0052:

1. `Sub Name` `a` and `Public Name` `b` are each named, but the entire string `a.b` has no identifier.
2. In a standard clearnet URL containing a DNS domain name, the `host` field refers to the entire string `a.b`, NOT to a portion of it, ie `b`.  So `host` is NOT equivalent to `Public Name` as stated.
3. The `host` field of a URL may be interpreted as various things, eg: ipv4 addr, ipv6 addr, dns domain name, or another name resolution system, according to the url's scheme.  With "safe://" URL scheme, the `host` field can contain either XOR id or NRS name.  So, really the closest analogy is not URL `host`, but DNS `domain name`.
4. The entire `a.b` name is intended to be publically visible and resolvable.  Hence, it seems erroneous to call only the rightmost portion of it `public name`.  This gives the appearance that the subname portions are somehow not public, and is confusing.

In order to finalize my [pull-request](<https://github.com/maidsafe/safe-api/pull/529>) to SafeApi XorUrlEncoder (now SafeUrl), (1) and (4) need to be resolved somehow so we know what to name properties and methods and keep the code and RFC consistent. That is the real goal of these changes.